### PR TITLE
Add AI web programming lab notebooks and generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# AI in Web Programming Lab Notebooks
+
+A collection of twelve weekly lab notebooks lives under `ai-web/labs`. Each notebook follows the same structure (objectives, learning outcomes, prerequisites, guided steps, validation checks with local curl commands, and homework extensions) while covering the specific topics from the course brief.
+
+## Regenerating the notebooks
+
+The notebooks can be regenerated locally using the helper script.
+
+```bash
+# Install the single dependency if it is not already available
+pip install nbformat
+
+# Generate or refresh the notebooks
+python generate_ai_web_lab_notebooks.py
+```
+
+Running the script recreates the `ai-web/labs` directory and populates it with fresh notebook content. All commands are meant to be executed locally so that API keys remain protected on the backend.

--- a/ai-web/labs/Lab01_FastAPI_CRA_and_Git.ipynb
+++ b/ai-web/labs/Lab01_FastAPI_CRA_and_Git.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "467f598d",
+   "metadata": {},
+   "source": [
+    "# Lab 01 · FastAPI, CRA, and Git\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16b4b2dc",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- A FastAPI backend is scaffolded with health and echo routes.\n",
+    "- A Create React App frontend is outlined without using Vite.\n",
+    "- A Git repository is initialized with environment templates."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64c70007",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- The structure of a basic FastAPI service is reviewed.\n",
+    "- Development-time CORS settings are configured.\n",
+    "- Create React App scaffolding steps are rehearsed.\n",
+    "- Git initialization practices are reinforced."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "941c4bef",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "python --version\n",
+    "node --version\n",
+    "npm --version\n",
+    "git --version\n",
+    "\n",
+    "# Backend environment preparation (local execution only)\n",
+    "cd ai-web/backend\n",
+    "python -m venv .venv\n",
+    "# Windows: .venv\\Scripts\\activate\n",
+    "# Unix/macOS:\n",
+    ". .venv/bin/activate\n",
+    "pip install fastapi uvicorn[standard] pydantic python-dotenv google-generativeai faiss-cpu numpy\n",
+    "\n",
+    "# Frontend creation (Create React App; no Vite)\n",
+    "cd ../../\n",
+    "npx create-react-app frontend\n",
+    "cd frontend\n",
+    "npm install\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57f419af",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "Each step is executed locally so backend keys remain protected.\n",
+    "\n",
+    "### Step 1: Backend folder layout\n",
+    "A backend folder is created and populated with required files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95bd9ff5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "base = Path(\"ai-web/backend\")\n",
+    "(base / \"app\").mkdir(parents=True, exist_ok=True)\n",
+    "(base / \"app\" / \"__init__.py\").write_text(\"\n",
+    "\")\n",
+    "(base / \".env.example\").write_text('# Environment variables (never commit real keys)\n",
+    "GEMINI_API_KEY=\n",
+    "')\n",
+    "(base / \"requirements.txt\").write_text('''fastapi\n",
+    "uvicorn[standard]\n",
+    "pydantic\n",
+    "python-dotenv\n",
+    "google-generativeai\n",
+    "faiss-cpu\n",
+    "numpy\n",
+    "''')\n",
+    "(base / \"app\" / \"main.py\").write_text('''from fastapi import FastAPI\n",
+    "from fastapi.middleware.cors import CORSMiddleware\n",
+    "from pydantic import BaseModel\n",
+    "\n",
+    "app = FastAPI()\n",
+    "app.add_middleware(\n",
+    "    CORSMiddleware,\n",
+    "    allow_origins=[\"http://localhost:3000\"],\n",
+    "    allow_methods=[\"*\"],\n",
+    "    allow_headers=[\"*\"],\n",
+    ")\n",
+    "\n",
+    "\n",
+    "class EchoIn(BaseModel):\n",
+    "    msg: str\n",
+    "\n",
+    "\n",
+    "@app.get(\"/health\")\n",
+    "def health():\n",
+    "    return {\"status\": \"ok\"}\n",
+    "\n",
+    "\n",
+    "@app.post(\"/echo\")\n",
+    "def echo(payload: EchoIn):\n",
+    "    return {\"msg\": payload.msg}\n",
+    "''')\n",
+    "print(\"Backend scaffold was written under ai-web/backend.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7732749a",
+   "metadata": {},
+   "source": [
+    "### Step 2: Frontend placeholders\n",
+    "Frontend placeholders are positioned so Create React App components can be customized."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c0335ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "src = Path(\"ai-web/frontend/src\")\n",
+    "(src / \"lib\").mkdir(parents=True, exist_ok=True)\n",
+    "(src / \"lib\" / \"api.js\").write_text('''const BASE = process.env.REACT_APP_API_BASE || \"http://localhost:8000\";\n",
+    "\n",
+    "export async function post(path, body) {\n",
+    "  const res = await fetch(`${BASE}${path}`, {\n",
+    "    method: 'POST',\n",
+    "    headers: { 'Content-Type': 'application/json' },\n",
+    "    body: JSON.stringify(body)\n",
+    "  });\n",
+    "  if (!res.ok) {\n",
+    "    throw new Error(`HTTP ${res.status}`);\n",
+    "  }\n",
+    "  return res.json();\n",
+    "}\n",
+    "''')\n",
+    "(src / \"App.js\").write_text('''import React, { useState } from 'react';\n",
+    "import { post } from './lib/api';\n",
+    "\n",
+    "function App() {\n",
+    "  const [msg, setMsg] = useState('hello');\n",
+    "  const [response, setResponse] = useState('');\n",
+    "  const [loading, setLoading] = useState(false);\n",
+    "  const [error, setError] = useState('');\n",
+    "\n",
+    "  async function handleSend() {\n",
+    "    setLoading(true);\n",
+    "    setError('');\n",
+    "    try {\n",
+    "      const json = await post('/echo', { msg });\n",
+    "      setResponse(json.msg);\n",
+    "    } catch (err) {\n",
+    "      setError(String(err));\n",
+    "    } finally {\n",
+    "      setLoading(false);\n",
+    "    }\n",
+    "  }\n",
+    "\n",
+    "  return (\n",
+    "    <main style={{ padding: 24 }}>\n",
+    "      <h1>Lab 1 — Echo demo</h1>\n",
+    "      <input value={msg} onChange={(event) => setMsg(event.target.value)} />\n",
+    "      <button onClick={handleSend} disabled={loading}>Send</button>\n",
+    "      {loading && <p>Loading…</p>}\n",
+    "      {error && <p style={{ color: 'red' }}>{error}</p>}\n",
+    "      <pre>{response}</pre>\n",
+    "    </main>\n",
+    "  );\n",
+    "}\n",
+    "\n",
+    "export default App;\n",
+    "''')\n",
+    "print(\"Frontend placeholders were written under ai-web/frontend/src.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6f8935c",
+   "metadata": {},
+   "source": [
+    "### Step 3: Git initialization\n",
+    "Git is initialized locally so changes can be tracked."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e7e903f",
+   "metadata": {},
+   "source": [
+    "```bash\n",
+    "cd ai-web\n",
+    "git init\n",
+    "git add .\n",
+    "git commit -m \"Lab 1 scaffold\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3728acf9",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl http://localhost:8000/health\n",
+    "curl -X POST http://localhost:8000/echo -H 'Content-Type: application/json' -d '{\"msg\":\"hello\"}'\n",
+    "```\n",
+    "- HTTP 200 responses include status \"ok\" and the echoed payload.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "201265c3",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- A README entry is expanded to document backend and frontend start commands.\n",
+    "- A GitHub repository is connected for remote backups."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab02_HTTP_Forms_and_Retry.ipynb
+++ b/ai-web/labs/Lab02_HTTP_Forms_and_Retry.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a0af8698",
+   "metadata": {},
+   "source": [
+    "# Lab 02 · HTTP Forms and Retry\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f5996cd",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- A robust fetch helper with retry logic is introduced.\n",
+    "- A controlled React form is configured with loading and error feedback.\n",
+    "- Friendly error messages are surfaced in the UI."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b95786a",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- Retry helpers are structured for frontend HTTP calls.\n",
+    "- Controlled form patterns in React are rehearsed.\n",
+    "- Error boundaries in simple forms are practiced."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4334fb15",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "cd ai-web/frontend\n",
+    "npm install\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14db1484",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "### Step 1: Retry helper placement\n",
+    "A retry helper is positioned under src/lib."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25f1e0b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "lib = Path(\"ai-web/frontend/src/lib\")\n",
+    "lib.mkdir(parents=True, exist_ok=True)\n",
+    "(lib / \"retry.js\").write_text('''export async function withRetry(fn, attempts = 2, delayMs = 400) {\n",
+    "  let lastError;\n",
+    "  for (let attempt = 0; attempt <= attempts; attempt += 1) {\n",
+    "    try {\n",
+    "      return await fn();\n",
+    "    } catch (error) {\n",
+    "      lastError = error;\n",
+    "    }\n",
+    "    await new Promise((resolve) => setTimeout(resolve, delayMs));\n",
+    "  }\n",
+    "  throw lastError;\n",
+    "}\n",
+    "''')\n",
+    "print(\"Retry helper was written.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "518be421",
+   "metadata": {},
+   "source": [
+    "### Step 2: Form integration\n",
+    "App.js is updated so the retry helper wraps the echo request and error states remain friendly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b61f4b6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "app_js = Path(\"ai-web/frontend/src/App.js\")\n",
+    "text = app_js.read_text()\n",
+    "if \"withRetry\" not in text:\n",
+    "    text = text.replace(\n",
+    "        \"import { post } from './lib/api';\",\n",
+    "        \"import { post } from './lib/api';\n",
+    "import { withRetry } from './lib/retry';\",\n",
+    "    )\n",
+    "if \"withRetry\" in text and \"withRetry(() => post\" not in text:\n",
+    "    text = text.replace(\n",
+    "        \"const json = await post('/echo', { msg });\",\n",
+    "        \"const json = await withRetry(() => post('/echo', { msg }), 2, 500);\",\n",
+    "    )\n",
+    "if \"setError(String(err));\" in text:\n",
+    "    text = text.replace(\n",
+    "        \"setError(String(err));\",\n",
+    "        \"setError('A temporary issue was encountered. Please try again.');\",\n",
+    "    )\n",
+    "app_js.write_text(text)\n",
+    "print(\"App.js was adjusted for retry and friendly errors.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd67b660",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl -X POST http://localhost:8000/echo -H 'Content-Type: application/json' -d '{\"msg\":\"retry\"}'\n",
+    "```\n",
+    "- The echoed payload is returned successfully after transient failures are simulated.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "637adf6b",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- Additional retry backoff strategies are outlined for future reference.\n",
+    "- Form validation rules are drafted to prevent empty submissions."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab03_Gemini_Proxy_Chat.ipynb
+++ b/ai-web/labs/Lab03_Gemini_Proxy_Chat.ipynb
@@ -1,0 +1,244 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "33eeeba7",
+   "metadata": {},
+   "source": [
+    "# Lab 03 · Gemini Proxy Chat\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47de6f88",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- A Gemini proxy endpoint is created in FastAPI.\n",
+    "- React chat UI components are connected to the proxy.\n",
+    "- API keys remain confined to the backend."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef4a0618",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- Backend proxy patterns for hosted LLMs are practiced.\n",
+    "- Basic chat state management in React is reviewed.\n",
+    "- Environment variable usage is reinforced."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "373bf681",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "cd ai-web/backend\n",
+    ". .venv/bin/activate\n",
+    "pip install google-generativeai\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07a89a5a",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "### Step 1: Gemini helper module\n",
+    "A backend helper is written so Gemini calls are centralized."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e02eb74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "module = Path(\"ai-web/backend/app/llm.py\")\n",
+    "module.parent.mkdir(parents=True, exist_ok=True)\n",
+    "module.write_text('''import os\n",
+    "from typing import List, Dict\n",
+    "\n",
+    "import google.generativeai as genai\n",
+    "\n",
+    "\n",
+    "def chat(messages: List[Dict[str, str]]) -> str:\n",
+    "  api_key = os.environ.get('GEMINI_API_KEY', '')\n",
+    "  if not api_key:\n",
+    "    raise RuntimeError('A backend API key is required.')\n",
+    "  genai.configure(api_key=api_key)\n",
+    "  model = genai.GenerativeModel('gemini-1.5-flash')\n",
+    "  response = model.generate_content(messages)\n",
+    "  return response.text\n",
+    "''')\n",
+    "print(\"Gemini helper was written.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "210a4d10",
+   "metadata": {},
+   "source": [
+    "### Step 2: FastAPI route update\n",
+    "The FastAPI app is expanded with /api/chat."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "550f0ebb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "main_path = Path(\"ai-web/backend/app/main.py\")\n",
+    "text = main_path.read_text()\n",
+    "addition = '''\n",
+    "from typing import List\n",
+    "from pydantic import BaseModel\n",
+    "from .llm import chat as gemini_chat\n",
+    "\n",
+    "\n",
+    "class ChatTurn(BaseModel):\n",
+    "    role: str\n",
+    "    content: str\n",
+    "\n",
+    "\n",
+    "class ChatRequest(BaseModel):\n",
+    "    messages: List[ChatTurn]\n",
+    "\n",
+    "\n",
+    "@app.post(\"/api/chat\")\n",
+    "def chat_endpoint(request: ChatRequest):\n",
+    "    transcript = [\n",
+    "        {\"role\": turn.role, \"parts\": [turn.content]} for turn in request.messages\n",
+    "    ]\n",
+    "    text = gemini_chat(transcript)\n",
+    "    return {\"text\": text}\n",
+    "'''\n",
+    "if \"chat_endpoint\" not in text:\n",
+    "    main_path.write_text(text.rstrip() + \"\n",
+    "\" + addition)\n",
+    "    print(\"FastAPI route was appended.\")\n",
+    "else:\n",
+    "    print(\"FastAPI route already present.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd5dc6d4",
+   "metadata": {},
+   "source": [
+    "### Step 3: React chat surface\n",
+    "A lightweight chat component is appended to App.js so the proxy is exercised."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "168ba811",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "app_js = Path(\"ai-web/frontend/src/App.js\")\n",
+    "app_js.write_text('''import React, { useState } from 'react';\n",
+    "import { post } from './lib/api';\n",
+    "import { withRetry } from './lib/retry';\n",
+    "\n",
+    "function App() {\n",
+    "  const [messages, setMessages] = useState([{ role: 'user', content: 'Hello Gemini' }]);\n",
+    "  const [input, setInput] = useState('');\n",
+    "  const [loading, setLoading] = useState(false);\n",
+    "  const [error, setError] = useState('');\n",
+    "\n",
+    "  async function handleSend(event) {\n",
+    "    event.preventDefault();\n",
+    "    const updated = [...messages, { role: 'user', content: input }];\n",
+    "    setMessages(updated);\n",
+    "    setLoading(true);\n",
+    "    setError('');\n",
+    "    try {\n",
+    "      const result = await withRetry(\n",
+    "        () => post('/api/chat', { messages: updated }),\n",
+    "        1,\n",
+    "        800\n",
+    "      );\n",
+    "      setMessages([...updated, { role: 'model', content: result.text }]);\n",
+    "      setInput('');\n",
+    "    } catch (err) {\n",
+    "      setError('The proxy was unreachable. Please try again.');\n",
+    "    } finally {\n",
+    "      setLoading(false);\n",
+    "    }\n",
+    "  }\n",
+    "\n",
+    "  return (\n",
+    "    <main style={{ padding: 24 }}>\n",
+    "      <h1>Lab 3 — Gemini proxy chat</h1>\n",
+    "      <section>\n",
+    "        {messages.map((msg, index) => (\n",
+    "          <p key={index}>\n",
+    "            <strong>{msg.role}:</strong> {msg.content}\n",
+    "          </p>\n",
+    "        ))}\n",
+    "      </section>\n",
+    "      <form onSubmit={handleSend}>\n",
+    "        <input\n",
+    "          value={input}\n",
+    "          onChange={(event) => setInput(event.target.value)}\n",
+    "          placeholder=\"Type a follow-up\"\n",
+    "        />\n",
+    "        <button type=\"submit\" disabled={loading || !input}>Send</button>\n",
+    "      </form>\n",
+    "      {loading && <p>Awaiting proxy response…</p>}\n",
+    "      {error && <p style={{ color: 'red' }}>{error}</p>}\n",
+    "    </main>\n",
+    "  );\n",
+    "}\n",
+    "\n",
+    "export default App;\n",
+    "''')\n",
+    "print(\"Chat UI was seeded.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2c989a1",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl -X POST http://localhost:8000/api/chat -H 'Content-Type: application/json' -d '{\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'\n",
+    "```\n",
+    "- A JSON response with a text field is produced by the backend proxy.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9be9d3cf",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- Streaming responses are researched for future enhancements.\n",
+    "- Chat history persistence is sketched for the next lab."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab04_Structured_JSON_and_Validation.ipynb
+++ b/ai-web/labs/Lab04_Structured_JSON_and_Validation.ipynb
@@ -1,0 +1,174 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4d537063",
+   "metadata": {},
+   "source": [
+    "# Lab 04 · Structured JSON and Validation\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "696a6db3",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- A planner endpoint is produced that returns structured JSON.\n",
+    "- Pydantic validation is applied to enforce schema guarantees.\n",
+    "- Automatic repair strategies are outlined for invalid JSON."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b095e13f",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- Structured JSON responses are validated on the backend.\n",
+    "- Error handling flows for invalid planner output are reviewed.\n",
+    "- Lightweight repair attempts are documented for client consumption."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de2a0237",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "cd ai-web/backend\n",
+    ". .venv/bin/activate\n",
+    "pip install pydantic\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "011e2425",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "### Step 1: Planner schema definition\n",
+    "A schema is defined so planner responses remain consistent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e172ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "planner_path = Path(\"ai-web/backend/app/planner.py\")\n",
+    "planner_path.write_text('''from pydantic import BaseModel, Field, ValidationError\n",
+    "from typing import List\n",
+    "\n",
+    "\n",
+    "class Plan(BaseModel):\n",
+    "    goal: str = Field(..., description=\"High level objective\")\n",
+    "    steps: List[str] = Field(default_factory=list, description=\"Ordered plan steps\")\n",
+    "\n",
+    "\n",
+    "def build_plan(goal: str) -> Plan:\n",
+    "    steps = [\n",
+    "        \"It is ensured that the goal is clarified.\",\n",
+    "        \"Resources are gathered to support the plan.\",\n",
+    "        \"Progress is reviewed upon completion.\",\n",
+    "    ]\n",
+    "    return Plan(goal=goal, steps=steps)\n",
+    "\n",
+    "\n",
+    "def repair_plan(data: dict) -> Plan:\n",
+    "    try:\n",
+    "        return Plan(**data)\n",
+    "    except ValidationError as exc:\n",
+    "        fixed = {\"goal\": data.get(\"goal\", \"A goal was recorded.\"), \"steps\": []}\n",
+    "        for idx, issue in enumerate(exc.errors()):\n",
+    "            fixed[\"steps\"].append(f\"Step {idx + 1} was replaced because {issue['msg']}\")\n",
+    "        return Plan(**fixed)\n",
+    "''')\n",
+    "print(\"Planner module was written.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "233bd136",
+   "metadata": {},
+   "source": [
+    "### Step 2: API exposure\n",
+    "The planner endpoint is exposed at /api/plan with validation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee6da1d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "main_path = Path(\"ai-web/backend/app/main.py\")\n",
+    "text = main_path.read_text()\n",
+    "if \"plan_endpoint\" not in text:\n",
+    "    addition = '''\n",
+    "from pydantic import BaseModel\n",
+    "from .planner import build_plan, repair_plan\n",
+    "\n",
+    "\n",
+    "class PlanIn(BaseModel):\n",
+    "    goal: str\n",
+    "\n",
+    "\n",
+    "@app.post(\"/api/plan\")\n",
+    "def plan_endpoint(payload: PlanIn):\n",
+    "    plan = build_plan(payload.goal)\n",
+    "    return plan.model_dump()\n",
+    "\n",
+    "\n",
+    "@app.post(\"/api/plan/repair\")\n",
+    "def plan_repair_endpoint(payload: dict):\n",
+    "    plan = repair_plan(payload)\n",
+    "    return plan.model_dump()\n",
+    "'''\n",
+    "    main_path.write_text(text.rstrip() + \"\n",
+    "\" + addition)\n",
+    "    print(\"Planner routes were appended.\")\n",
+    "else:\n",
+    "    print(\"Planner routes already present.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d89179d6",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl -X POST http://localhost:8000/api/plan -H 'Content-Type: application/json' -d '{\"goal\":\"Build a demo\"}'\n",
+    "```\n",
+    "- A JSON object containing a goal and an ordered list of steps is returned.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df56a06e",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- Client-side rendering of planner steps is drafted for the frontend.\n",
+    "- Additional validation rules are explored for complex goals."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab05_Simple_Agent_and_Tools.ipynb
+++ b/ai-web/labs/Lab05_Simple_Agent_and_Tools.ipynb
@@ -1,0 +1,203 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "70fdff7b",
+   "metadata": {},
+   "source": [
+    "# Lab 05 · Simple Agent and Tools\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3b99789",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- A minimal agent loop is expressed with limited iterations.\n",
+    "- Tool abstractions for calculator, db_query, and search_faq are prepared.\n",
+    "- Tool call timelines are logged for review."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "317078da",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- Agent planning loops are reasoned about with deterministic stops.\n",
+    "- Tool registration strategies are documented.\n",
+    "- Logging of tool usage is practiced for observability."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e5cb507",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "cd ai-web/backend\n",
+    ". .venv/bin/activate\n",
+    "pip install numpy\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28bd09b6",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "### Step 1: Tool definitions\n",
+    "Lightweight tool functions are placed in a tools module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7623303a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "module = Path(\"ai-web/backend/app/tools.py\")\n",
+    "module.write_text('''from typing import Any, Dict, List\n",
+    "\n",
+    "\n",
+    "TOOL_LOG: List[Dict[str, Any]] = []\n",
+    "\n",
+    "\n",
+    "def calculator(expression: str) -> str:\n",
+    "    TOOL_LOG.append({\"tool\": \"calculator\", \"input\": expression})\n",
+    "    try:\n",
+    "        value = eval(expression, {\"__builtins__\": {}}, {})\n",
+    "    except Exception:\n",
+    "        return \"A calculation error was observed.\"\n",
+    "    return str(value)\n",
+    "\n",
+    "\n",
+    "def db_query(sql: str) -> str:\n",
+    "    TOOL_LOG.append({\"tool\": \"db_query\", \"input\": sql})\n",
+    "    return \"A mock database response was produced.\"\n",
+    "\n",
+    "\n",
+    "def search_faq(question: str) -> str:\n",
+    "    TOOL_LOG.append({\"tool\": \"search_faq\", \"input\": question})\n",
+    "    return \"A documented FAQ entry was suggested.\"\n",
+    "''')\n",
+    "print(\"Tools module was created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51574cb5",
+   "metadata": {},
+   "source": [
+    "### Step 2: Agent loop outline\n",
+    "A simple agent loop is introduced with a two-iteration limit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9174f9f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "agent_path = Path(\"ai-web/backend/app/agent.py\")\n",
+    "agent_path.write_text('''from typing import Dict, List\n",
+    "\n",
+    "from .tools import TOOL_LOG, calculator, db_query, search_faq\n",
+    "\n",
+    "\n",
+    "def run_agent(task: str) -> Dict[str, List[str]]:\n",
+    "    TOOL_LOG.clear()\n",
+    "    thoughts = [f\"The task was received: {task}\"]\n",
+    "    for step in range(2):\n",
+    "        if \"calculate\" in task and step == 0:\n",
+    "            result = calculator(\"1 + 1\")\n",
+    "            thoughts.append(f\"Calculator returned {result}.\")\n",
+    "        elif \"database\" in task and step == 0:\n",
+    "            result = db_query(\"SELECT * FROM items LIMIT 1\")\n",
+    "            thoughts.append(result)\n",
+    "        else:\n",
+    "            result = search_faq(task)\n",
+    "            thoughts.append(result)\n",
+    "    timeline = [f\"{entry['tool']} ← {entry['input']}\" for entry in TOOL_LOG]\n",
+    "    return {\"thoughts\": thoughts, \"timeline\": timeline}\n",
+    "''')\n",
+    "print(\"Agent loop was documented.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eaf65da0",
+   "metadata": {},
+   "source": [
+    "### Step 3: Endpoint exposure\n",
+    "The agent run is exposed through FastAPI for easy testing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53ceed7d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "main_path = Path(\"ai-web/backend/app/main.py\")\n",
+    "text = main_path.read_text()\n",
+    "if \"agent_endpoint\" not in text:\n",
+    "    addition = '''\n",
+    "from .agent import run_agent\n",
+    "\n",
+    "\n",
+    "@app.post(\"/api/agent\")\n",
+    "def agent_endpoint(payload: dict):\n",
+    "    task = payload.get(\"task\", \"A task was not specified.\")\n",
+    "    result = run_agent(task)\n",
+    "    return result\n",
+    "'''\n",
+    "    main_path.write_text(text.rstrip() + \"\n",
+    "\" + addition)\n",
+    "    print(\"Agent endpoint was appended.\")\n",
+    "else:\n",
+    "    print(\"Agent endpoint already present.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "611752a4",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl -X POST http://localhost:8000/api/agent -H 'Content-Type: application/json' -d '{\"task\":\"calculate 1+1\"}'\n",
+    "```\n",
+    "- The response includes thoughts and a timeline reflecting tool usage.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "616ef1af",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- Tool error handling pathways are drafted for robustness.\n",
+    "- Agent iteration limits are experimented with for longer plans."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab06_Embeddings_and_FAISS.ipynb
+++ b/ai-web/labs/Lab06_Embeddings_and_FAISS.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "eafe495a",
+   "metadata": {},
+   "source": [
+    "# Lab 06 · Embeddings and FAISS\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfea26d0",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- Document chunking routines are introduced.\n",
+    "- The \"text-embedding-004\" vectors are stored in a FAISS index.\n",
+    "- A search endpoint returns top results with scores."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0390110",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- Document preprocessing for embeddings is rehearsed.\n",
+    "- FAISS index persistence is described.\n",
+    "- Vector search endpoints are surfaced."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7eb68ac3",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "cd ai-web/backend\n",
+    ". .venv/bin/activate\n",
+    "pip install faiss-cpu google-generativeai numpy\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6f4be53",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "### Step 1: Chunking utility\n",
+    "A chunking helper is added so documents are segmented."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e83f8b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "vector_path = Path(\"ai-web/backend/app/vector.py\")\n",
+    "vector_path.write_text('''import json\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "from typing import List, Tuple\n",
+    "\n",
+    "import google.generativeai as genai\n",
+    "import numpy as np\n",
+    "import faiss\n",
+    "\n",
+    "\n",
+    "DATA_DIR = Path(__file__).resolve().parent / \"data\"\n",
+    "DATA_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "INDEX_FILE = DATA_DIR / \"embeddings.index\"\n",
+    "META_FILE = DATA_DIR / \"metadata.json\"\n",
+    "\n",
+    "\n",
+    "def chunk_text(text: str, size: int = 400) -> List[str]:\n",
+    "  return [text[i:i + size] for i in range(0, len(text), size) if text[i:i + size].strip()]\n",
+    "\n",
+    "\n",
+    "def embed_chunks(chunks: List[str]) -> np.ndarray:\n",
+    "  api_key = os.environ.get('GEMINI_API_KEY', '')\n",
+    "  if not api_key:\n",
+    "    raise RuntimeError('A backend API key is required for embeddings.')\n",
+    "  genai.configure(api_key=api_key)\n",
+    "  model = genai.EmbeddingModel(model_name='text-embedding-004')\n",
+    "  vectors = model.embed_content([{ \"title\": f\"Chunk {idx}\", \"content\": chunk } for idx, chunk in enumerate(chunks)])\n",
+    "  return np.array([item.values for item in vectors], dtype=np.float32)\n",
+    "\n",
+    "\n",
+    "def save_index(chunks: List[str], vectors: np.ndarray) -> None:\n",
+    "  index = faiss.IndexFlatIP(vectors.shape[1])\n",
+    "  faiss.normalize_L2(vectors)\n",
+    "  index.add(vectors)\n",
+    "  faiss.write_index(index, str(INDEX_FILE))\n",
+    "  META_FILE.write_text(json.dumps({\"chunks\": chunks}))\n",
+    "\n",
+    "\n",
+    "def load_index() -> Tuple[faiss.Index, List[str]]:\n",
+    "  index = faiss.read_index(str(INDEX_FILE))\n",
+    "  chunks = json.loads(META_FILE.read_text())[\"chunks\"]\n",
+    "  return index, chunks\n",
+    "\n",
+    "\n",
+    "def search(query: str, top_k: int = 3) -> List[Tuple[str, float]]:\n",
+    "  index, chunks = load_index()\n",
+    "  query_vec = embed_chunks([query])\n",
+    "  faiss.normalize_L2(query_vec)\n",
+    "  scores, neighbors = index.search(query_vec, top_k)\n",
+    "  return [(chunks[i], float(scores[0][pos])) for pos, i in enumerate(neighbors[0])]\n",
+    "''')\n",
+    "print(\"Vector helper was written.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0af0c4c5",
+   "metadata": {},
+   "source": [
+    "### Step 2: Index builder cell\n",
+    "An index is created from a small sample document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d51ca9ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.append(str(Path('ai-web/backend')))\n",
+    "from app.vector import chunk_text, embed_chunks, save_index\n",
+    "\n",
+    "sample_text = \"\"\"This course demonstrates AI in web programming.\n",
+    "The backend relies on FastAPI and Gemini proxies.\n",
+    "Vector search provides relevant snippets.\n",
+    "\"\"\"\n",
+    "chunks = chunk_text(sample_text)\n",
+    "vectors = embed_chunks(chunks)\n",
+    "save_index(chunks, vectors)\n",
+    "print('Index was generated with', len(chunks), 'chunks.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7f13eeb",
+   "metadata": {},
+   "source": [
+    "### Step 3: Search endpoint\n",
+    "A FastAPI endpoint is published for vector search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dafa4a26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "main_path = Path(\"ai-web/backend/app/main.py\")\n",
+    "text = main_path.read_text()\n",
+    "if \"search_endpoint\" not in text:\n",
+    "    addition = '''\n",
+    "from typing import Optional\n",
+    "from .vector import search\n",
+    "\n",
+    "\n",
+    "@app.get(\"/api/search\")\n",
+    "def search_endpoint(q: str, k: Optional[int] = 3):\n",
+    "    results = search(q, int(k))\n",
+    "    return {\"results\": [{\"text\": text, \"score\": score} for text, score in results]}\n",
+    "'''\n",
+    "    main_path.write_text(text.rstrip() + \"\n",
+    "\" + addition)\n",
+    "    print(\"Search endpoint was appended.\")\n",
+    "else:\n",
+    "    print(\"Search endpoint already present.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49212d07",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl 'http://localhost:8000/api/search?q=fastapi&k=2'\n",
+    "```\n",
+    "- A JSON response containing scored chunks is observed.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28f7d673",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- Periodic index rebuild strategies are evaluated for large document sets.\n",
+    "- Client-side rendering of search results is explored."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab07_RAG_with_Citations.ipynb
+++ b/ai-web/labs/Lab07_RAG_with_Citations.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ae2f02c9",
+   "metadata": {},
+   "source": [
+    "# Lab 07 · RAG with Citations\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f41ba182",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- Retrieved chunks are combined into grounded answers.\n",
+    "- Inline citation markers such as [S1] are emitted.\n",
+    "- Refusals are documented when no evidence is present."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8345e75c",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- Response assembly with citations is structured.\n",
+    "- Evidence gating ensures unsupported answers are refused.\n",
+    "- Backend orchestration for RAG is reinforced."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38b38581",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "cd ai-web/backend\n",
+    ". .venv/bin/activate\n",
+    "pip install google-generativeai\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5781869",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "### Step 1: RAG helper\n",
+    "A helper combines retrieved chunks with a Gemini completion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "973dad3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "rag_path = Path(\"ai-web/backend/app/rag.py\")\n",
+    "rag_path.write_text('''from typing import List\n",
+    "\n",
+    "from .vector import search\n",
+    "from .llm import chat\n",
+    "\n",
+    "\n",
+    "def answer(question: str) -> dict:\n",
+    "    retrieved = search(question, 3)\n",
+    "    if not retrieved:\n",
+    "        return {\"answer\": \"No supported answer can be provided without evidence.\", \"chunks\": []}\n",
+    "    citations = [f\"[S{idx + 1}]\" for idx in range(len(retrieved))]\n",
+    "    prompt = [\n",
+    "        {\"role\": \"user\", \"content\": f\"Question: {question}. Use only the provided snippets.\"},\n",
+    "        {\"role\": \"model\", \"content\": \"Sources:\n",
+    "\" + \"\n",
+    "\".join(f\"[S{idx + 1}] {text}\" for idx, (text, _) in enumerate(retrieved))}\n",
+    "    ]\n",
+    "    completion = chat(prompt)\n",
+    "    return {\"answer\": completion, \"chunks\": [{\"id\": f\"S{idx + 1}\", \"text\": text, \"score\": score} for idx, (text, score) in enumerate(retrieved)], \"citations\": citations}\n",
+    "''')\n",
+    "print(\"RAG helper was created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "879149c5",
+   "metadata": {},
+   "source": [
+    "### Step 2: Endpoint exposure\n",
+    "The RAG helper is surfaced under /api/answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e0aacec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "main_path = Path(\"ai-web/backend/app/main.py\")\n",
+    "text = main_path.read_text()\n",
+    "if \"answer_endpoint\" not in text:\n",
+    "    addition = '''\n",
+    "from .rag import answer as answer_question\n",
+    "\n",
+    "\n",
+    "@app.get(\"/api/answer\")\n",
+    "def answer_endpoint(q: str):\n",
+    "    result = answer_question(q)\n",
+    "    if not result.get(\"chunks\"):\n",
+    "        return {\"answer\": \"No supported answer can be provided without evidence.\", \"citations\": []}\n",
+    "    return result\n",
+    "'''\n",
+    "    main_path.write_text(text.rstrip() + \"\n",
+    "\" + addition)\n",
+    "    print(\"Answer endpoint was appended.\")\n",
+    "else:\n",
+    "    print(\"Answer endpoint already present.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "720687ad",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl 'http://localhost:8000/api/answer?q=course goals'\n",
+    "```\n",
+    "- A cited answer referencing [S1] style markers is produced when evidence exists.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "857f2b98",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- Citation rendering is enhanced in the frontend chat UI.\n",
+    "- Fallback messaging is drafted for unanswered questions."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab08_TensorFlowJS_Browser_Inference.ipynb
+++ b/ai-web/labs/Lab08_TensorFlowJS_Browser_Inference.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6722c9de",
+   "metadata": {},
+   "source": [
+    "# Lab 08 · TensorFlow.js Browser Inference\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0148de7a",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- TensorFlow.js is loaded in the browser for local inference.\n",
+    "- A webcam or file input is provided without backend calls.\n",
+    "- Prediction results are rendered with lightweight styling."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "179764da",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- Client-side model loading is rehearsed.\n",
+    "- User media APIs are reviewed for inference demos.\n",
+    "- Result presentation is refined for clarity."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9f936c1",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "cd ai-web/frontend\n",
+    "npm install @tensorflow/tfjs @tensorflow-models/coco-ssd\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "123c3413",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "### Step 1: Component shell\n",
+    "A React component is outlined for TensorFlow.js usage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad2bb2e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "app_js = Path(\"ai-web/frontend/src/App.js\")\n",
+    "app_js.write_text('''import React, { useEffect, useRef, useState } from 'react';\n",
+    "import * as cocoSsd from '@tensorflow-models/coco-ssd';\n",
+    "import '@tensorflow/tfjs';\n",
+    "\n",
+    "function App() {\n",
+    "  const videoRef = useRef(null);\n",
+    "  const canvasRef = useRef(null);\n",
+    "  const [status, setStatus] = useState('Model is loading…');\n",
+    "  const [model, setModel] = useState(null);\n",
+    "\n",
+    "  useEffect(() => {\n",
+    "    async function prepare() {\n",
+    "      try {\n",
+    "        const loaded = await cocoSsd.load();\n",
+    "        setModel(loaded);\n",
+    "        setStatus('Model is ready.');\n",
+    "        const stream = await navigator.mediaDevices.getUserMedia({ video: true });\n",
+    "        if (videoRef.current) {\n",
+    "          videoRef.current.srcObject = stream;\n",
+    "        }\n",
+    "      } catch (error) {\n",
+    "        setStatus('Camera or model initialization failed.');\n",
+    "      }\n",
+    "    }\n",
+    "    prepare();\n",
+    "  }, []);\n",
+    "\n",
+    "  async function handleDetect() {\n",
+    "    if (!model || !videoRef.current) {\n",
+    "      setStatus('Detection is unavailable at this time.');\n",
+    "      return;\n",
+    "    }\n",
+    "    const predictions = await model.detect(videoRef.current);\n",
+    "    const canvas = canvasRef.current;\n",
+    "    const context = canvas.getContext('2d');\n",
+    "    context.clearRect(0, 0, canvas.width, canvas.height);\n",
+    "    context.font = '16px sans-serif';\n",
+    "    predictions.forEach((prediction, index) => {\n",
+    "      context.fillText(`${index + 1}. ${prediction.class} (${prediction.score.toFixed(2)})`, 10, 20 + index * 18);\n",
+    "    });\n",
+    "    setStatus(`${predictions.length} objects were detected.`);\n",
+    "  }\n",
+    "\n",
+    "  return (\n",
+    "    <main style={{ padding: 24 }}>\n",
+    "      <h1>Lab 8 — TensorFlow.js Inference</h1>\n",
+    "      <p>{status}</p>\n",
+    "      <video ref={videoRef} width={320} height={240} autoPlay playsInline muted />\n",
+    "      <canvas ref={canvasRef} width={320} height={240} style={{ border: '1px solid #ccc' }} />\n",
+    "      <button type=\"button\" onClick={handleDetect}>Run detection</button>\n",
+    "    </main>\n",
+    "  );\n",
+    "}\n",
+    "\n",
+    "export default App;\n",
+    "''')\n",
+    "print(\"TensorFlow.js demo was written.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a60d5bf",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl http://localhost:8000/health\n",
+    "```\n",
+    "- The backend health check remains accessible while the frontend serves the TensorFlow.js UI.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a46dbef",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- Image upload support is investigated for offline detection.\n",
+    "- Result overlays are explored to highlight detections on the video feed."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab09_Agent_Memory_SQLite.ipynb
+++ b/ai-web/labs/Lab09_Agent_Memory_SQLite.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6eb6fdb4",
+   "metadata": {},
+   "source": [
+    "# Lab 09 · Agent Memory with SQLite\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72adcddf",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- A SQLite schema is designed for sessions, messages, and memories.\n",
+    "- A memory summarization plan is drafted for periodic runs.\n",
+    "- Data access helpers are introduced."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c137e4bf",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- SQLite migrations are sketched for conversational data.\n",
+    "- Summarization planning is discussed for memory consolidation.\n",
+    "- Repository patterns for data access are reinforced."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a451c225",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "cd ai-web/backend\n",
+    ". .venv/bin/activate\n",
+    "pip install sqlite-utils\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dc7091f",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "### Step 1: Schema file\n",
+    "A schema file is provided to capture sessions, messages, and memories."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e00b9006",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "schema_path = Path(\"ai-web/backend/app/schema.sql\")\n",
+    "schema_path.write_text('''CREATE TABLE IF NOT EXISTS sessions (\n",
+    "  id TEXT PRIMARY KEY,\n",
+    "  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n",
+    ");\n",
+    "\n",
+    "CREATE TABLE IF NOT EXISTS messages (\n",
+    "  id INTEGER PRIMARY KEY AUTOINCREMENT,\n",
+    "  session_id TEXT REFERENCES sessions(id),\n",
+    "  role TEXT,\n",
+    "  content TEXT,\n",
+    "  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n",
+    ");\n",
+    "\n",
+    "CREATE TABLE IF NOT EXISTS memories (\n",
+    "  id INTEGER PRIMARY KEY AUTOINCREMENT,\n",
+    "  session_id TEXT REFERENCES sessions(id),\n",
+    "  summary TEXT,\n",
+    "  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,\n",
+    "  next_review TIMESTAMP\n",
+    ");\n",
+    "''')\n",
+    "print(\"Schema file was produced.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c69356ca",
+   "metadata": {},
+   "source": [
+    "### Step 2: Repository helper\n",
+    "A helper module is included for interacting with SQLite."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1dc250a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "repo_path = Path(\"ai-web/backend/app/repository.py\")\n",
+    "repo_path.write_text('''import sqlite3\n",
+    "from pathlib import Path\n",
+    "from typing import Iterable\n",
+    "\n",
+    "DB_PATH = Path(__file__).resolve().parent / \"data.sqlite3\"\n",
+    "\n",
+    "\n",
+    "def get_connection():\n",
+    "    conn = sqlite3.connect(DB_PATH)\n",
+    "    conn.row_factory = sqlite3.Row\n",
+    "    return conn\n",
+    "\n",
+    "\n",
+    "def apply_schema(schema_sql: str):\n",
+    "    conn = get_connection()\n",
+    "    conn.executescript(schema_sql)\n",
+    "    conn.commit()\n",
+    "    conn.close()\n",
+    "\n",
+    "\n",
+    "def insert_message(session_id: str, role: str, content: str):\n",
+    "    conn = get_connection()\n",
+    "    conn.execute(\n",
+    "        \"INSERT INTO messages (session_id, role, content) VALUES (?, ?, ?)\",\n",
+    "        (session_id, role, content),\n",
+    "    )\n",
+    "    conn.commit()\n",
+    "    conn.close()\n",
+    "\n",
+    "\n",
+    "def list_recent_messages(session_id: str, limit: int = 10) -> Iterable[sqlite3.Row]:\n",
+    "    conn = get_connection()\n",
+    "    rows = conn.execute(\n",
+    "        \"SELECT role, content FROM messages WHERE session_id = ? ORDER BY created_at DESC LIMIT ?\",\n",
+    "        (session_id, limit),\n",
+    "    ).fetchall()\n",
+    "    conn.close()\n",
+    "    return rows\n",
+    "''')\n",
+    "print(\"Repository helper was created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5776f80",
+   "metadata": {},
+   "source": [
+    "### Step 3: Summarization plan\n",
+    "A plan is described to summarize conversations periodically."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cbf2648",
+   "metadata": {},
+   "source": [
+    "A periodic job is proposed in which conversations are summarized into the memories table. The job is scheduled after a session surpasses a message threshold. A placeholder function is positioned so later labs can hook in summarization calls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45302bbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "plan_path = Path(\"ai-web/backend/app/memory_plan.py\")\n",
+    "plan_path.write_text('''from datetime import datetime, timedelta\n",
+    "\n",
+    "\n",
+    "def plan_memory_summary(session_id: str) -> dict:\n",
+    "    return {\n",
+    "        \"session_id\": session_id,\n",
+    "        \"next_review\": (datetime.utcnow() + timedelta(hours=6)).isoformat(),\n",
+    "        \"status\": \"A summarization run has been scheduled.\",\n",
+    "    }\n",
+    "''')\n",
+    "print(\"Memory plan placeholder was drafted.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f960332",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl http://localhost:8000/health\n",
+    "```\n",
+    "- The backend health endpoint remains operational after SQLite helpers are introduced.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "101c0a03",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- A cron-style schedule is documented for invoking the summarization plan.\n",
+    "- Additional indexing strategies are explored for the messages table."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab10_Evaluation_Latency_Cache.ipynb
+++ b/ai-web/labs/Lab10_Evaluation_Latency_Cache.ipynb
@@ -1,0 +1,200 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bf73da21",
+   "metadata": {},
+   "source": [
+    "# Lab 10 · Evaluation, Latency, and Cache\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2d9c448",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- A tiny evaluation set is logged for backend prompts.\n",
+    "- Latency and token usage metrics are recorded.\n",
+    "- A naive cache hashes prompt plus tool context."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f1a900f",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- Evaluation harness design is reviewed for LLM flows.\n",
+    "- Latency tracking is reinforced with timestamp instrumentation.\n",
+    "- Cache strategies are described for simple reuse."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c90538b0",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "cd ai-web/backend\n",
+    ". .venv/bin/activate\n",
+    "pip install google-generativeai\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b1b3a65",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "### Step 1: Evaluation dataset stub\n",
+    "A small evaluation dataset is stored for reproducibility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88cdfeee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "fixture_path = Path(\"ai-web/backend/app/eval_set.json\")\n",
+    "fixture_path.write_text('''[\n",
+    "  {\"prompt\": \"Summarize the project goals.\", \"expected\": \"A concise description is returned.\"},\n",
+    "  {\"prompt\": \"List backend components.\", \"expected\": \"FastAPI, FAISS, and Gemini proxy are noted.\"}\n",
+    "]\n",
+    "''')\n",
+    "print(\"Evaluation dataset was created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "939f65f1",
+   "metadata": {},
+   "source": [
+    "### Step 2: Metrics helper\n",
+    "A helper is provided to time requests and count tokens."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "548cd4a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "metrics_path = Path(\"ai-web/backend/app/metrics.py\")\n",
+    "metrics_path.write_text('''import hashlib\n",
+    "import json\n",
+    "import time\n",
+    "from contextlib import contextmanager\n",
+    "from typing import Dict\n",
+    "\n",
+    "TOKEN_LOG: Dict[str, int] = {}\n",
+    "\n",
+    "\n",
+    "@contextmanager\n",
+    "def track_latency(label: str):\n",
+    "    start = time.perf_counter()\n",
+    "    yield\n",
+    "    duration = time.perf_counter() - start\n",
+    "    print(f\"{label} latency: {duration:.3f}s\")\n",
+    "\n",
+    "\n",
+    "def cache_key(prompt: str, tools: str) -> str:\n",
+    "    payload = json.dumps({\"prompt\": prompt, \"tools\": tools}, sort_keys=True)\n",
+    "    return hashlib.sha256(payload.encode('utf-8')).hexdigest()\n",
+    "\n",
+    "\n",
+    "def record_tokens(label: str, count: int):\n",
+    "    TOKEN_LOG[label] = TOKEN_LOG.get(label, 0) + count\n",
+    "''')\n",
+    "print(\"Metrics helper was written.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fca8da2",
+   "metadata": {},
+   "source": [
+    "### Step 3: Cache-enabled endpoint\n",
+    "An evaluation endpoint is instrumented with caching and latency tracking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb6b7a03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "main_path = Path(\"ai-web/backend/app/main.py\")\n",
+    "text = main_path.read_text()\n",
+    "if \"evaluation_endpoint\" not in text:\n",
+    "    addition = '''\n",
+    "from .metrics import cache_key, record_tokens, track_latency\n",
+    "from .llm import chat as llm_chat\n",
+    "\n",
+    "CACHE = {}\n",
+    "\n",
+    "\n",
+    "@app.post(\"/api/evaluate\")\n",
+    "def evaluation_endpoint(payload: dict):\n",
+    "    prompt = payload.get(\"prompt\", \"\")\n",
+    "    tools = \"\".join(payload.get(\"tools\", []))\n",
+    "    key = cache_key(prompt, tools)\n",
+    "    if key in CACHE:\n",
+    "        return {\"cached\": True, \"response\": CACHE[key]}\n",
+    "    with track_latency(\"evaluation\"):\n",
+    "        response = llm_chat([\n",
+    "            {\"role\": \"user\", \"content\": prompt}\n",
+    "        ])\n",
+    "    record_tokens(\"evaluation\", len(prompt.split()))\n",
+    "    CACHE[key] = response\n",
+    "    return {\"cached\": False, \"response\": response}\n",
+    "'''\n",
+    "    main_path.write_text(text.rstrip() + \"\n",
+    "\" + addition)\n",
+    "    print(\"Evaluation endpoint was appended.\")\n",
+    "else:\n",
+    "    print(\"Evaluation endpoint already present.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bb4d25c",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl -X POST http://localhost:8000/api/evaluate -H 'Content-Type: application/json' -d '{\"prompt\":\"Summarize the project goals.\"}'\n",
+    "```\n",
+    "- Responses indicate whether cache hits occurred and include evaluation output.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10b8ecfd",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- Token accounting is integrated with external monitoring dashboards.\n",
+    "- Additional evaluation prompts are composed for regression coverage."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab11_Security_and_Hardening.ipynb
+++ b/ai-web/labs/Lab11_Security_and_Hardening.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "64613843",
+   "metadata": {},
+   "source": [
+    "# Lab 11 · Security and Hardening\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59a1b763",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- Production CORS settings are tightened.\n",
+    "- Payload limits and allow-lists are described.\n",
+    "- SlowAPI rate limiting and prompt-injection checklists are provided."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21c427cc",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- Environment-specific CORS strategies are reinforced.\n",
+    "- Input validation patterns are documented for safety.\n",
+    "- Prompt-injection mitigations are rehearsed for RAG systems."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e688540",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "cd ai-web/backend\n",
+    ". .venv/bin/activate\n",
+    "pip install slowapi\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c58254e",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "### Step 1: Security settings module\n",
+    "Security utilities are collected for reuse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c71592e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "security_path = Path(\"ai-web/backend/app/security.py\")\n",
+    "security_path.write_text('''from slowapi import Limiter\n",
+    "from slowapi.util import get_remote_address\n",
+    "from fastapi import FastAPI\n",
+    "from fastapi.middleware.cors import CORSMiddleware\n",
+    "\n",
+    "SAFE_ORIGINS = [\"https://example.com\"]\n",
+    "ALLOWED_FILES = {\".txt\", \".md\"}\n",
+    "limiter = Limiter(key_func=get_remote_address, default_limits=[\"60/minute\"])\n",
+    "\n",
+    "\n",
+    "def configure_security(app: FastAPI):\n",
+    "    app.state.limiter = limiter\n",
+    "    app.add_middleware(\n",
+    "        CORSMiddleware,\n",
+    "        allow_origins=SAFE_ORIGINS,\n",
+    "        allow_credentials=True,\n",
+    "        allow_methods=[\"GET\", \"POST\"],\n",
+    "        allow_headers=[\"Content-Type\", \"Authorization\"],\n",
+    "    )\n",
+    "''')\n",
+    "print(\"Security module was written.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23c79e95",
+   "metadata": {},
+   "source": [
+    "### Step 2: Payload guard\n",
+    "A payload guard demonstrates enforcing limits and allow-lists."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83f47ef0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "limits_path = Path(\"ai-web/backend/app/guards.py\")\n",
+    "limits_path.write_text('''from fastapi import HTTPException, UploadFile\n",
+    "\n",
+    "MAX_PAYLOAD_BYTES = 1024 * 1024\n",
+    "ALLOWED_EXTENSIONS = {\".txt\", \".md\", \".pdf\"}\n",
+    "\n",
+    "\n",
+    "def enforce_size(data: bytes):\n",
+    "    if len(data) > MAX_PAYLOAD_BYTES:\n",
+    "        raise HTTPException(status_code=413, detail=\"Payload size limit was exceeded.\")\n",
+    "\n",
+    "\n",
+    "def enforce_extension(upload: UploadFile):\n",
+    "    if not any(upload.filename.endswith(ext) for ext in ALLOWED_EXTENSIONS):\n",
+    "        raise HTTPException(status_code=400, detail=\"File extension was not allowed.\")\n",
+    "''')\n",
+    "print(\"Payload guard was documented.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f31ad787",
+   "metadata": {},
+   "source": [
+    "### Step 3: Prompt-injection checklist\n",
+    "A checklist is referenced for the RAG pipeline."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5d32128",
+   "metadata": {},
+   "source": [
+    "A checklist is maintained:\n",
+    "- External instructions are screened for deny-list phrases.\n",
+    "- Citations are verified prior to response emission.\n",
+    "- Sensitive tools are disabled when citations are missing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cc51d21",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl http://localhost:8000/health\n",
+    "```\n",
+    "- The hardened configuration preserves the health endpoint for monitoring.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecd1a035",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- Rate limiting thresholds are tuned for production traffic patterns.\n",
+    "- Security review notes are captured alongside deployment manifests."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab12_Deployment_and_Docker.ipynb
+++ b/ai-web/labs/Lab12_Deployment_and_Docker.ipynb
@@ -1,0 +1,166 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5814107b",
+   "metadata": {},
+   "source": [
+    "# Lab 12 · Deployment and Docker\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "863f7d58",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- A backend Dockerfile is drafted with environment configuration guidance.\n",
+    "- A docker-compose sketch is recorded for local orchestration.\n",
+    "- Frontend build and deployment checklists are enumerated."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4da72b7",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- Containerization patterns are reviewed for FastAPI and React.\n",
+    "- Environment variable documentation is reinforced for deployment.\n",
+    "- Health check considerations are summarized for operations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66f15c6a",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "# Docker installation is confirmed locally\n",
+    "docker --version\n",
+    "docker compose version\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0dd9505",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "### Step 1: Backend Dockerfile\n",
+    "A Dockerfile is created for the FastAPI backend."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80026770",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "dockerfile_path = Path(\"ai-web/backend/Dockerfile\")\n",
+    "dockerfile_path.write_text('''FROM python:3.11-slim\n",
+    "ENV PYTHONDONTWRITEBYTECODE=1\n",
+    "ENV PYTHONUNBUFFERED=1\n",
+    "WORKDIR /app\n",
+    "COPY requirements.txt ./\n",
+    "RUN pip install --no-cache-dir -r requirements.txt\n",
+    "COPY . ./\n",
+    "CMD [\"uvicorn\", \"app.main:app\", \"--host\", \"0.0.0.0\", \"--port\", \"8000\"]\n",
+    "''')\n",
+    "print(\"Backend Dockerfile was created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "793c839e",
+   "metadata": {},
+   "source": [
+    "### Step 2: Compose sketch\n",
+    "A docker-compose.yml sketch references backend and frontend builds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d54eb45e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "compose_path = Path(\"ai-web/docker-compose.yml\")\n",
+    "compose_path.write_text('''version: '3.9'\n",
+    "services:\n",
+    "  backend:\n",
+    "    build: ./backend\n",
+    "    environment:\n",
+    "      - GEMINI_API_KEY=${GEMINI_API_KEY}\n",
+    "    ports:\n",
+    "      - \"8000:8000\"\n",
+    "  frontend:\n",
+    "    build: ./frontend\n",
+    "    ports:\n",
+    "      - \"3000:3000\"\n",
+    "    environment:\n",
+    "      - REACT_APP_API_BASE=http://localhost:8000\n",
+    "''')\n",
+    "print(\"Compose sketch was drafted.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a74f075",
+   "metadata": {},
+   "source": [
+    "### Step 3: Deployment checklist\n",
+    "Deployment steps are summarized for future reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70cb67ea",
+   "metadata": {},
+   "source": [
+    "A deployment checklist is tracked:\n",
+    "- Environment files are reviewed and populated without committing secrets.\n",
+    "- docker compose build and docker compose up commands are executed locally for testing.\n",
+    "- Health checks are observed via /health before promoting changes.\n",
+    "- A demo script is outlined describing backend startup, frontend build, and proxy verification."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c61db12",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl http://localhost:8000/health\n",
+    "```\n",
+    "- Container builds expose the health endpoint for readiness checks.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e83443c",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- CI/CD pipeline steps are enumerated for automated deployments.\n",
+    "- Frontend build artifacts are hosted on a static site provider checklist."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/generate_ai_web_lab_notebooks.py
+++ b/generate_ai_web_lab_notebooks.py
@@ -1,0 +1,1624 @@
+import nbformat as nbf
+from pathlib import Path
+import textwrap
+
+ROOT = Path("ai-web/labs")
+ROOT.mkdir(parents=True, exist_ok=True)
+
+
+def md(text: str):
+    return nbf.v4.new_markdown_cell(textwrap.dedent(text).strip())
+
+
+def code(text: str):
+    return nbf.v4.new_code_cell(textwrap.dedent(text).strip())
+
+
+def notebook(title: str, cells):
+    nb = nbf.v4.new_notebook()
+    nb.cells = [
+        md(
+            f"# {title}\n\n*This lab notebook provides guided steps. All commands are intended for local execution.*"
+        )
+    ]
+    nb.cells.extend(cells)
+    return nb
+
+
+def write_notebook(name: str, title: str, cells):
+    path = ROOT / f"{name}.ipynb"
+    with path.open("w", encoding="utf-8") as handle:
+        nbf.write(notebook(title, cells), handle)
+    print(f"Written: {path}")
+
+
+def acceptance(commands: str, expectations: str):
+    return md(
+        f"## Validation / acceptance checks\n```bash\n# locally\n{commands}\n```\n- {expectations}\n- React development mode shows the described UI state without console errors."
+    )
+
+
+def homework(items):
+    bullet = "\n".join(f"- {item}" for item in items)
+    return md(f"## Homework / extensions\n{bullet}")
+
+
+labs = []
+
+# ---------------------------------------------------------------------------
+# Lab 01
+lab1_cells = [
+    md(
+        """## Objectives
+- A FastAPI backend is scaffolded with health and echo routes.
+- A Create React App frontend is outlined without using Vite.
+- A Git repository is initialized with environment templates.
+"""
+    ),
+    md(
+        """## What will be learned
+- The structure of a basic FastAPI service is reviewed.
+- Development-time CORS settings are configured.
+- Create React App scaffolding steps are rehearsed.
+- Git initialization practices are reinforced.
+"""
+    ),
+    md(
+        """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+python --version
+node --version
+npm --version
+git --version
+
+# Backend environment preparation (local execution only)
+cd ai-web/backend
+python -m venv .venv
+# Windows: .venv\\Scripts\\activate
+# Unix/macOS:
+. .venv/bin/activate
+pip install fastapi uvicorn[standard] pydantic python-dotenv google-generativeai faiss-cpu numpy
+
+# Frontend creation (Create React App; no Vite)
+cd ../../
+npx create-react-app frontend
+cd frontend
+npm install
+```
+"""
+    ),
+    md(
+        """## Step-by-step tasks
+Each step is executed locally so backend keys remain protected.
+
+### Step 1: Backend folder layout
+A backend folder is created and populated with required files.
+"""
+    ),
+    code(
+        """
+from pathlib import Path
+base = Path("ai-web/backend")
+(base / "app").mkdir(parents=True, exist_ok=True)
+(base / "app" / "__init__.py").write_text("\n")
+(base / ".env.example").write_text('# Environment variables (never commit real keys)\nGEMINI_API_KEY=\n')
+(base / "requirements.txt").write_text('''fastapi
+uvicorn[standard]
+pydantic
+python-dotenv
+google-generativeai
+faiss-cpu
+numpy
+''')
+(base / "app" / "main.py").write_text('''from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class EchoIn(BaseModel):
+    msg: str
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/echo")
+def echo(payload: EchoIn):
+    return {"msg": payload.msg}
+''')
+print("Backend scaffold was written under ai-web/backend.")
+"""
+    ),
+    md(
+        """### Step 2: Frontend placeholders
+Frontend placeholders are positioned so Create React App components can be customized.
+"""
+    ),
+    code(
+        """
+from pathlib import Path
+src = Path("ai-web/frontend/src")
+(src / "lib").mkdir(parents=True, exist_ok=True)
+(src / "lib" / "api.js").write_text('''const BASE = process.env.REACT_APP_API_BASE || "http://localhost:8000";
+
+export async function post(path, body) {
+  const res = await fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return res.json();
+}
+''')
+(src / "App.js").write_text('''import React, { useState } from 'react';
+import { post } from './lib/api';
+
+function App() {
+  const [msg, setMsg] = useState('hello');
+  const [response, setResponse] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSend() {
+    setLoading(true);
+    setError('');
+    try {
+      const json = await post('/echo', { msg });
+      setResponse(json.msg);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Lab 1 — Echo demo</h1>
+      <input value={msg} onChange={(event) => setMsg(event.target.value)} />
+      <button onClick={handleSend} disabled={loading}>Send</button>
+      {loading && <p>Loading…</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <pre>{response}</pre>
+    </main>
+  );
+}
+
+export default App;
+''')
+print("Frontend placeholders were written under ai-web/frontend/src.")
+"""
+    ),
+    md(
+        """### Step 3: Git initialization
+Git is initialized locally so changes can be tracked.
+"""
+    ),
+    md(
+        """
+```bash
+cd ai-web
+git init
+git add .
+git commit -m "Lab 1 scaffold"
+```
+"""
+    ),
+    acceptance(
+        "curl http://localhost:8000/health\ncurl -X POST http://localhost:8000/echo -H 'Content-Type: application/json' -d '{\"msg\":\"hello\"}'",
+        "HTTP 200 responses include status \"ok\" and the echoed payload.",
+    ),
+    homework([
+        "A README entry is expanded to document backend and frontend start commands.",
+        "A GitHub repository is connected for remote backups.",
+    ]),
+]
+
+labs.append(("Lab01_FastAPI_CRA_and_Git", "Lab 01 · FastAPI, CRA, and Git", lab1_cells))
+
+# ---------------------------------------------------------------------------
+# Lab 02
+lab2_cells = [
+    md(
+        """## Objectives
+- A robust fetch helper with retry logic is introduced.
+- A controlled React form is configured with loading and error feedback.
+- Friendly error messages are surfaced in the UI.
+"""
+    ),
+    md(
+        """## What will be learned
+- Retry helpers are structured for frontend HTTP calls.
+- Controlled form patterns in React are rehearsed.
+- Error boundaries in simple forms are practiced.
+"""
+    ),
+    md(
+        """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+cd ai-web/frontend
+npm install
+```
+"""
+    ),
+    md(
+        """## Step-by-step tasks
+### Step 1: Retry helper placement
+A retry helper is positioned under src/lib.
+"""
+    ),
+    code(
+        """
+from pathlib import Path
+lib = Path("ai-web/frontend/src/lib")
+lib.mkdir(parents=True, exist_ok=True)
+(lib / "retry.js").write_text('''export async function withRetry(fn, attempts = 2, delayMs = 400) {
+  let lastError;
+  for (let attempt = 0; attempt <= attempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  throw lastError;
+}
+''')
+print("Retry helper was written.")
+"""
+    ),
+    md(
+        """### Step 2: Form integration
+App.js is updated so the retry helper wraps the echo request and error states remain friendly.
+"""
+    ),
+    code(
+        """
+from pathlib import Path
+app_js = Path("ai-web/frontend/src/App.js")
+text = app_js.read_text()
+if "withRetry" not in text:
+    text = text.replace(
+        "import { post } from './lib/api';",
+        "import { post } from './lib/api';\nimport { withRetry } from './lib/retry';",
+    )
+if "withRetry" in text and "withRetry(() => post" not in text:
+    text = text.replace(
+        "const json = await post('/echo', { msg });",
+        "const json = await withRetry(() => post('/echo', { msg }), 2, 500);",
+    )
+if "setError(String(err));" in text:
+    text = text.replace(
+        "setError(String(err));",
+        "setError('A temporary issue was encountered. Please try again.');",
+    )
+app_js.write_text(text)
+print("App.js was adjusted for retry and friendly errors.")
+"""
+    ),
+    acceptance(
+        "curl -X POST http://localhost:8000/echo -H 'Content-Type: application/json' -d '{\"msg\":\"retry\"}'",
+        "The echoed payload is returned successfully after transient failures are simulated.",
+    ),
+    homework([
+        "Additional retry backoff strategies are outlined for future reference.",
+        "Form validation rules are drafted to prevent empty submissions.",
+    ]),
+]
+
+labs.append(("Lab02_HTTP_Forms_and_Retry", "Lab 02 · HTTP Forms and Retry", lab2_cells))
+
+# ---------------------------------------------------------------------------
+# Lab 03
+lab3_cells = [
+    md(
+        """## Objectives
+- A Gemini proxy endpoint is created in FastAPI.
+- React chat UI components are connected to the proxy.
+- API keys remain confined to the backend.
+"""
+    ),
+    md(
+        """## What will be learned
+- Backend proxy patterns for hosted LLMs are practiced.
+- Basic chat state management in React is reviewed.
+- Environment variable usage is reinforced.
+"""
+    ),
+    md(
+        """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+cd ai-web/backend
+. .venv/bin/activate
+pip install google-generativeai
+```
+"""
+    ),
+    md(
+        """## Step-by-step tasks
+### Step 1: Gemini helper module
+A backend helper is written so Gemini calls are centralized.
+"""
+    ),
+    code(
+        """
+from pathlib import Path
+module = Path("ai-web/backend/app/llm.py")
+module.parent.mkdir(parents=True, exist_ok=True)
+module.write_text('''import os
+from typing import List, Dict
+
+import google.generativeai as genai
+
+
+def chat(messages: List[Dict[str, str]]) -> str:
+  api_key = os.environ.get('GEMINI_API_KEY', '')
+  if not api_key:
+    raise RuntimeError('A backend API key is required.')
+  genai.configure(api_key=api_key)
+  model = genai.GenerativeModel('gemini-1.5-flash')
+  response = model.generate_content(messages)
+  return response.text
+''')
+print("Gemini helper was written.")
+"""
+    ),
+    md(
+        """### Step 2: FastAPI route update
+The FastAPI app is expanded with /api/chat.
+"""
+    ),
+    code(
+        """
+from pathlib import Path
+main_path = Path("ai-web/backend/app/main.py")
+text = main_path.read_text()
+addition = '''
+from typing import List
+from pydantic import BaseModel
+from .llm import chat as gemini_chat
+
+
+class ChatTurn(BaseModel):
+    role: str
+    content: str
+
+
+class ChatRequest(BaseModel):
+    messages: List[ChatTurn]
+
+
+@app.post("/api/chat")
+def chat_endpoint(request: ChatRequest):
+    transcript = [
+        {"role": turn.role, "parts": [turn.content]} for turn in request.messages
+    ]
+    text = gemini_chat(transcript)
+    return {"text": text}
+'''
+if "chat_endpoint" not in text:
+    main_path.write_text(text.rstrip() + "\n" + addition)
+    print("FastAPI route was appended.")
+else:
+    print("FastAPI route already present.")
+"""
+    ),
+    md(
+        """### Step 3: React chat surface
+A lightweight chat component is appended to App.js so the proxy is exercised.
+"""
+    ),
+    code(
+        """
+from pathlib import Path
+app_js = Path("ai-web/frontend/src/App.js")
+app_js.write_text('''import React, { useState } from 'react';
+import { post } from './lib/api';
+import { withRetry } from './lib/retry';
+
+function App() {
+  const [messages, setMessages] = useState([{ role: 'user', content: 'Hello Gemini' }]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSend(event) {
+    event.preventDefault();
+    const updated = [...messages, { role: 'user', content: input }];
+    setMessages(updated);
+    setLoading(true);
+    setError('');
+    try {
+      const result = await withRetry(
+        () => post('/api/chat', { messages: updated }),
+        1,
+        800
+      );
+      setMessages([...updated, { role: 'model', content: result.text }]);
+      setInput('');
+    } catch (err) {
+      setError('The proxy was unreachable. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Lab 3 — Gemini proxy chat</h1>
+      <section>
+        {messages.map((msg, index) => (
+          <p key={index}>
+            <strong>{msg.role}:</strong> {msg.content}
+          </p>
+        ))}
+      </section>
+      <form onSubmit={handleSend}>
+        <input
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          placeholder="Type a follow-up"
+        />
+        <button type="submit" disabled={loading || !input}>Send</button>
+      </form>
+      {loading && <p>Awaiting proxy response…</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </main>
+  );
+}
+
+export default App;
+''')
+print("Chat UI was seeded.")
+"""
+    ),
+    acceptance(
+        "curl -X POST http://localhost:8000/api/chat -H 'Content-Type: application/json' -d '{\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'",
+        "A JSON response with a text field is produced by the backend proxy.",
+    ),
+    homework([
+        "Streaming responses are researched for future enhancements.",
+        "Chat history persistence is sketched for the next lab.",
+    ]),
+]
+
+labs.append(("Lab03_Gemini_Proxy_Chat", "Lab 03 · Gemini Proxy Chat", lab3_cells))
+
+# ---------------------------------------------------------------------------
+# Additional labs
+
+labs.append((
+    "Lab04_Structured_JSON_and_Validation",
+    "Lab 04 · Structured JSON and Validation",
+    [
+        md(
+            """## Objectives
+- A planner endpoint is produced that returns structured JSON.
+- Pydantic validation is applied to enforce schema guarantees.
+- Automatic repair strategies are outlined for invalid JSON.
+"""
+        ),
+        md(
+            """## What will be learned
+- Structured JSON responses are validated on the backend.
+- Error handling flows for invalid planner output are reviewed.
+- Lightweight repair attempts are documented for client consumption.
+"""
+        ),
+        md(
+            """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+cd ai-web/backend
+. .venv/bin/activate
+pip install pydantic
+```
+"""
+        ),
+        md(
+            """## Step-by-step tasks
+### Step 1: Planner schema definition
+A schema is defined so planner responses remain consistent.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+planner_path = Path("ai-web/backend/app/planner.py")
+planner_path.write_text('''from pydantic import BaseModel, Field, ValidationError
+from typing import List
+
+
+class Plan(BaseModel):
+    goal: str = Field(..., description="High level objective")
+    steps: List[str] = Field(default_factory=list, description="Ordered plan steps")
+
+
+def build_plan(goal: str) -> Plan:
+    steps = [
+        "It is ensured that the goal is clarified.",
+        "Resources are gathered to support the plan.",
+        "Progress is reviewed upon completion.",
+    ]
+    return Plan(goal=goal, steps=steps)
+
+
+def repair_plan(data: dict) -> Plan:
+    try:
+        return Plan(**data)
+    except ValidationError as exc:
+        fixed = {"goal": data.get("goal", "A goal was recorded."), "steps": []}
+        for idx, issue in enumerate(exc.errors()):
+            fixed["steps"].append(f"Step {idx + 1} was replaced because {issue['msg']}")
+        return Plan(**fixed)
+''')
+print("Planner module was written.")
+"""
+        ),
+        md(
+            """### Step 2: API exposure
+The planner endpoint is exposed at /api/plan with validation.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+main_path = Path("ai-web/backend/app/main.py")
+text = main_path.read_text()
+if "plan_endpoint" not in text:
+    addition = '''
+from pydantic import BaseModel
+from .planner import build_plan, repair_plan
+
+
+class PlanIn(BaseModel):
+    goal: str
+
+
+@app.post("/api/plan")
+def plan_endpoint(payload: PlanIn):
+    plan = build_plan(payload.goal)
+    return plan.model_dump()
+
+
+@app.post("/api/plan/repair")
+def plan_repair_endpoint(payload: dict):
+    plan = repair_plan(payload)
+    return plan.model_dump()
+'''
+    main_path.write_text(text.rstrip() + "\n" + addition)
+    print("Planner routes were appended.")
+else:
+    print("Planner routes already present.")
+"""
+        ),
+        acceptance(
+            "curl -X POST http://localhost:8000/api/plan -H 'Content-Type: application/json' -d '{\"goal\":\"Build a demo\"}'",
+            "A JSON object containing a goal and an ordered list of steps is returned.",
+        ),
+        homework([
+            "Client-side rendering of planner steps is drafted for the frontend.",
+            "Additional validation rules are explored for complex goals.",
+        ]),
+    ],
+))
+
+labs.append((
+    "Lab05_Simple_Agent_and_Tools",
+    "Lab 05 · Simple Agent and Tools",
+    [
+        md(
+            """## Objectives
+- A minimal agent loop is expressed with limited iterations.
+- Tool abstractions for calculator, db_query, and search_faq are prepared.
+- Tool call timelines are logged for review.
+"""
+        ),
+        md(
+            """## What will be learned
+- Agent planning loops are reasoned about with deterministic stops.
+- Tool registration strategies are documented.
+- Logging of tool usage is practiced for observability.
+"""
+        ),
+        md(
+            """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+cd ai-web/backend
+. .venv/bin/activate
+pip install numpy
+```
+"""
+        ),
+        md(
+            """## Step-by-step tasks
+### Step 1: Tool definitions
+Lightweight tool functions are placed in a tools module.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+module = Path("ai-web/backend/app/tools.py")
+module.write_text('''from typing import Any, Dict, List
+
+
+TOOL_LOG: List[Dict[str, Any]] = []
+
+
+def calculator(expression: str) -> str:
+    TOOL_LOG.append({"tool": "calculator", "input": expression})
+    try:
+        value = eval(expression, {"__builtins__": {}}, {})
+    except Exception:
+        return "A calculation error was observed."
+    return str(value)
+
+
+def db_query(sql: str) -> str:
+    TOOL_LOG.append({"tool": "db_query", "input": sql})
+    return "A mock database response was produced."
+
+
+def search_faq(question: str) -> str:
+    TOOL_LOG.append({"tool": "search_faq", "input": question})
+    return "A documented FAQ entry was suggested."
+''')
+print("Tools module was created.")
+"""
+        ),
+        md(
+            """### Step 2: Agent loop outline
+A simple agent loop is introduced with a two-iteration limit.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+agent_path = Path("ai-web/backend/app/agent.py")
+agent_path.write_text('''from typing import Dict, List
+
+from .tools import TOOL_LOG, calculator, db_query, search_faq
+
+
+def run_agent(task: str) -> Dict[str, List[str]]:
+    TOOL_LOG.clear()
+    thoughts = [f"The task was received: {task}"]
+    for step in range(2):
+        if "calculate" in task and step == 0:
+            result = calculator("1 + 1")
+            thoughts.append(f"Calculator returned {result}.")
+        elif "database" in task and step == 0:
+            result = db_query("SELECT * FROM items LIMIT 1")
+            thoughts.append(result)
+        else:
+            result = search_faq(task)
+            thoughts.append(result)
+    timeline = [f"{entry['tool']} ← {entry['input']}" for entry in TOOL_LOG]
+    return {"thoughts": thoughts, "timeline": timeline}
+''')
+print("Agent loop was documented.")
+"""
+        ),
+        md(
+            """### Step 3: Endpoint exposure
+The agent run is exposed through FastAPI for easy testing.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+main_path = Path("ai-web/backend/app/main.py")
+text = main_path.read_text()
+if "agent_endpoint" not in text:
+    addition = '''
+from .agent import run_agent
+
+
+@app.post("/api/agent")
+def agent_endpoint(payload: dict):
+    task = payload.get("task", "A task was not specified.")
+    result = run_agent(task)
+    return result
+'''
+    main_path.write_text(text.rstrip() + "\n" + addition)
+    print("Agent endpoint was appended.")
+else:
+    print("Agent endpoint already present.")
+"""
+        ),
+        acceptance(
+            "curl -X POST http://localhost:8000/api/agent -H 'Content-Type: application/json' -d '{\"task\":\"calculate 1+1\"}'",
+            "The response includes thoughts and a timeline reflecting tool usage.",
+        ),
+        homework([
+            "Tool error handling pathways are drafted for robustness.",
+            "Agent iteration limits are experimented with for longer plans.",
+        ]),
+    ],
+))
+
+labs.append((
+    "Lab06_Embeddings_and_FAISS",
+    "Lab 06 · Embeddings and FAISS",
+    [
+        md(
+            """## Objectives
+- Document chunking routines are introduced.
+- The \"text-embedding-004\" vectors are stored in a FAISS index.
+- A search endpoint returns top results with scores.
+"""
+        ),
+        md(
+            """## What will be learned
+- Document preprocessing for embeddings is rehearsed.
+- FAISS index persistence is described.
+- Vector search endpoints are surfaced.
+"""
+        ),
+        md(
+            """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+cd ai-web/backend
+. .venv/bin/activate
+pip install faiss-cpu google-generativeai numpy
+```
+"""
+        ),
+        md(
+            """## Step-by-step tasks
+### Step 1: Chunking utility
+A chunking helper is added so documents are segmented.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+vector_path = Path("ai-web/backend/app/vector.py")
+vector_path.write_text('''import json
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+import google.generativeai as genai
+import numpy as np
+import faiss
+
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+INDEX_FILE = DATA_DIR / "embeddings.index"
+META_FILE = DATA_DIR / "metadata.json"
+
+
+def chunk_text(text: str, size: int = 400) -> List[str]:
+  return [text[i:i + size] for i in range(0, len(text), size) if text[i:i + size].strip()]
+
+
+def embed_chunks(chunks: List[str]) -> np.ndarray:
+  api_key = os.environ.get('GEMINI_API_KEY', '')
+  if not api_key:
+    raise RuntimeError('A backend API key is required for embeddings.')
+  genai.configure(api_key=api_key)
+  model = genai.EmbeddingModel(model_name='text-embedding-004')
+  vectors = model.embed_content([{ "title": f"Chunk {idx}", "content": chunk } for idx, chunk in enumerate(chunks)])
+  return np.array([item.values for item in vectors], dtype=np.float32)
+
+
+def save_index(chunks: List[str], vectors: np.ndarray) -> None:
+  index = faiss.IndexFlatIP(vectors.shape[1])
+  faiss.normalize_L2(vectors)
+  index.add(vectors)
+  faiss.write_index(index, str(INDEX_FILE))
+  META_FILE.write_text(json.dumps({"chunks": chunks}))
+
+
+def load_index() -> Tuple[faiss.Index, List[str]]:
+  index = faiss.read_index(str(INDEX_FILE))
+  chunks = json.loads(META_FILE.read_text())["chunks"]
+  return index, chunks
+
+
+def search(query: str, top_k: int = 3) -> List[Tuple[str, float]]:
+  index, chunks = load_index()
+  query_vec = embed_chunks([query])
+  faiss.normalize_L2(query_vec)
+  scores, neighbors = index.search(query_vec, top_k)
+  return [(chunks[i], float(scores[0][pos])) for pos, i in enumerate(neighbors[0])]
+''')
+print("Vector helper was written.")
+"""
+        ),
+        md(
+            """### Step 2: Index builder cell
+An index is created from a small sample document.
+"""
+        ),
+        code(
+            """
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path('ai-web/backend')))
+from app.vector import chunk_text, embed_chunks, save_index
+
+sample_text = "\"\"This course demonstrates AI in web programming.\nThe backend relies on FastAPI and Gemini proxies.\nVector search provides relevant snippets.\n\"\"\"
+chunks = chunk_text(sample_text)
+vectors = embed_chunks(chunks)
+save_index(chunks, vectors)
+print('Index was generated with', len(chunks), 'chunks.')
+"""
+        ),
+        md(
+            """### Step 3: Search endpoint
+A FastAPI endpoint is published for vector search.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+main_path = Path("ai-web/backend/app/main.py")
+text = main_path.read_text()
+if "search_endpoint" not in text:
+    addition = '''
+from typing import Optional
+from .vector import search
+
+
+@app.get("/api/search")
+def search_endpoint(q: str, k: Optional[int] = 3):
+    results = search(q, int(k))
+    return {"results": [{"text": text, "score": score} for text, score in results]}
+'''
+    main_path.write_text(text.rstrip() + "\n" + addition)
+    print("Search endpoint was appended.")
+else:
+    print("Search endpoint already present.")
+"""
+        ),
+        acceptance(
+            "curl 'http://localhost:8000/api/search?q=fastapi&k=2'",
+            "A JSON response containing scored chunks is observed.",
+        ),
+        homework([
+            "Periodic index rebuild strategies are evaluated for large document sets.",
+            "Client-side rendering of search results is explored.",
+        ]),
+    ],
+))
+
+labs.append((
+    "Lab07_RAG_with_Citations",
+    "Lab 07 · RAG with Citations",
+    [
+        md(
+            """## Objectives
+- Retrieved chunks are combined into grounded answers.
+- Inline citation markers such as [S1] are emitted.
+- Refusals are documented when no evidence is present.
+"""
+        ),
+        md(
+            """## What will be learned
+- Response assembly with citations is structured.
+- Evidence gating ensures unsupported answers are refused.
+- Backend orchestration for RAG is reinforced.
+"""
+        ),
+        md(
+            """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+cd ai-web/backend
+. .venv/bin/activate
+pip install google-generativeai
+```
+"""
+        ),
+        md(
+            """## Step-by-step tasks
+### Step 1: RAG helper
+A helper combines retrieved chunks with a Gemini completion.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+rag_path = Path("ai-web/backend/app/rag.py")
+rag_path.write_text('''from typing import List
+
+from .vector import search
+from .llm import chat
+
+
+def answer(question: str) -> dict:
+    retrieved = search(question, 3)
+    if not retrieved:
+        return {"answer": "No supported answer can be provided without evidence.", "chunks": []}
+    citations = [f"[S{idx + 1}]" for idx in range(len(retrieved))]
+    prompt = [
+        {"role": "user", "content": f"Question: {question}. Use only the provided snippets."},
+        {"role": "model", "content": "Sources:\n" + "\n".join(f"[S{idx + 1}] {text}" for idx, (text, _) in enumerate(retrieved))}
+    ]
+    completion = chat(prompt)
+    return {"answer": completion, "chunks": [{"id": f"S{idx + 1}", "text": text, "score": score} for idx, (text, score) in enumerate(retrieved)], "citations": citations}
+''')
+print("RAG helper was created.")
+"""
+        ),
+        md(
+            """### Step 2: Endpoint exposure
+The RAG helper is surfaced under /api/answer.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+main_path = Path("ai-web/backend/app/main.py")
+text = main_path.read_text()
+if "answer_endpoint" not in text:
+    addition = '''
+from .rag import answer as answer_question
+
+
+@app.get("/api/answer")
+def answer_endpoint(q: str):
+    result = answer_question(q)
+    if not result.get("chunks"):
+        return {"answer": "No supported answer can be provided without evidence.", "citations": []}
+    return result
+'''
+    main_path.write_text(text.rstrip() + "\n" + addition)
+    print("Answer endpoint was appended.")
+else:
+    print("Answer endpoint already present.")
+"""
+        ),
+        acceptance(
+            "curl 'http://localhost:8000/api/answer?q=course goals'",
+            "A cited answer referencing [S1] style markers is produced when evidence exists.",
+        ),
+        homework([
+            "Citation rendering is enhanced in the frontend chat UI.",
+            "Fallback messaging is drafted for unanswered questions.",
+        ]),
+    ],
+))
+
+labs.append((
+    "Lab08_TensorFlowJS_Browser_Inference",
+    "Lab 08 · TensorFlow.js Browser Inference",
+    [
+        md(
+            """## Objectives
+- TensorFlow.js is loaded in the browser for local inference.
+- A webcam or file input is provided without backend calls.
+- Prediction results are rendered with lightweight styling.
+"""
+        ),
+        md(
+            """## What will be learned
+- Client-side model loading is rehearsed.
+- User media APIs are reviewed for inference demos.
+- Result presentation is refined for clarity.
+"""
+        ),
+        md(
+            """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+cd ai-web/frontend
+npm install @tensorflow/tfjs @tensorflow-models/coco-ssd
+```
+"""
+        ),
+        md(
+            """## Step-by-step tasks
+### Step 1: Component shell
+A React component is outlined for TensorFlow.js usage.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+app_js = Path("ai-web/frontend/src/App.js")
+app_js.write_text('''import React, { useEffect, useRef, useState } from 'react';
+import * as cocoSsd from '@tensorflow-models/coco-ssd';
+import '@tensorflow/tfjs';
+
+function App() {
+  const videoRef = useRef(null);
+  const canvasRef = useRef(null);
+  const [status, setStatus] = useState('Model is loading…');
+  const [model, setModel] = useState(null);
+
+  useEffect(() => {
+    async function prepare() {
+      try {
+        const loaded = await cocoSsd.load();
+        setModel(loaded);
+        setStatus('Model is ready.');
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+        }
+      } catch (error) {
+        setStatus('Camera or model initialization failed.');
+      }
+    }
+    prepare();
+  }, []);
+
+  async function handleDetect() {
+    if (!model || !videoRef.current) {
+      setStatus('Detection is unavailable at this time.');
+      return;
+    }
+    const predictions = await model.detect(videoRef.current);
+    const canvas = canvasRef.current;
+    const context = canvas.getContext('2d');
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.font = '16px sans-serif';
+    predictions.forEach((prediction, index) => {
+      context.fillText(`${index + 1}. ${prediction.class} (${prediction.score.toFixed(2)})`, 10, 20 + index * 18);
+    });
+    setStatus(`${predictions.length} objects were detected.`);
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Lab 8 — TensorFlow.js Inference</h1>
+      <p>{status}</p>
+      <video ref={videoRef} width={320} height={240} autoPlay playsInline muted />
+      <canvas ref={canvasRef} width={320} height={240} style={{ border: '1px solid #ccc' }} />
+      <button type="button" onClick={handleDetect}>Run detection</button>
+    </main>
+  );
+}
+
+export default App;
+''')
+print("TensorFlow.js demo was written.")
+"""
+        ),
+        acceptance(
+            "curl http://localhost:8000/health",
+            "The backend health check remains accessible while the frontend serves the TensorFlow.js UI.",
+        ),
+        homework([
+            "Image upload support is investigated for offline detection.",
+            "Result overlays are explored to highlight detections on the video feed.",
+        ]),
+    ],
+))
+
+labs.append((
+    "Lab09_Agent_Memory_SQLite",
+    "Lab 09 · Agent Memory with SQLite",
+    [
+        md(
+            """## Objectives
+- A SQLite schema is designed for sessions, messages, and memories.
+- A memory summarization plan is drafted for periodic runs.
+- Data access helpers are introduced.
+"""
+        ),
+        md(
+            """## What will be learned
+- SQLite migrations are sketched for conversational data.
+- Summarization planning is discussed for memory consolidation.
+- Repository patterns for data access are reinforced.
+"""
+        ),
+        md(
+            """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+cd ai-web/backend
+. .venv/bin/activate
+pip install sqlite-utils
+```
+"""
+        ),
+        md(
+            """## Step-by-step tasks
+### Step 1: Schema file
+A schema file is provided to capture sessions, messages, and memories.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+schema_path = Path("ai-web/backend/app/schema.sql")
+schema_path.write_text('''CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT REFERENCES sessions(id),
+  role TEXT,
+  content TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS memories (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT REFERENCES sessions(id),
+  summary TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  next_review TIMESTAMP
+);
+''')
+print("Schema file was produced.")
+"""
+        ),
+        md(
+            """### Step 2: Repository helper
+A helper module is included for interacting with SQLite.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+repo_path = Path("ai-web/backend/app/repository.py")
+repo_path.write_text('''import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+DB_PATH = Path(__file__).resolve().parent / "data.sqlite3"
+
+
+def get_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def apply_schema(schema_sql: str):
+    conn = get_connection()
+    conn.executescript(schema_sql)
+    conn.commit()
+    conn.close()
+
+
+def insert_message(session_id: str, role: str, content: str):
+    conn = get_connection()
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content) VALUES (?, ?, ?)",
+        (session_id, role, content),
+    )
+    conn.commit()
+    conn.close()
+
+
+def list_recent_messages(session_id: str, limit: int = 10) -> Iterable[sqlite3.Row]:
+    conn = get_connection()
+    rows = conn.execute(
+        "SELECT role, content FROM messages WHERE session_id = ? ORDER BY created_at DESC LIMIT ?",
+        (session_id, limit),
+    ).fetchall()
+    conn.close()
+    return rows
+''')
+print("Repository helper was created.")
+"""
+        ),
+        md(
+            """### Step 3: Summarization plan
+A plan is described to summarize conversations periodically.
+"""
+        ),
+        md(
+            """A periodic job is proposed in which conversations are summarized into the memories table. The job is scheduled after a session surpasses a message threshold. A placeholder function is positioned so later labs can hook in summarization calls.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+plan_path = Path("ai-web/backend/app/memory_plan.py")
+plan_path.write_text('''from datetime import datetime, timedelta
+
+
+def plan_memory_summary(session_id: str) -> dict:
+    return {
+        "session_id": session_id,
+        "next_review": (datetime.utcnow() + timedelta(hours=6)).isoformat(),
+        "status": "A summarization run has been scheduled.",
+    }
+''')
+print("Memory plan placeholder was drafted.")
+"""
+        ),
+        acceptance(
+            "curl http://localhost:8000/health",
+            "The backend health endpoint remains operational after SQLite helpers are introduced.",
+        ),
+        homework([
+            "A cron-style schedule is documented for invoking the summarization plan.",
+            "Additional indexing strategies are explored for the messages table.",
+        ]),
+    ],
+))
+
+labs.append((
+    "Lab10_Evaluation_Latency_Cache",
+    "Lab 10 · Evaluation, Latency, and Cache",
+    [
+        md(
+            """## Objectives
+- A tiny evaluation set is logged for backend prompts.
+- Latency and token usage metrics are recorded.
+- A naive cache hashes prompt plus tool context.
+"""
+        ),
+        md(
+            """## What will be learned
+- Evaluation harness design is reviewed for LLM flows.
+- Latency tracking is reinforced with timestamp instrumentation.
+- Cache strategies are described for simple reuse.
+"""
+        ),
+        md(
+            """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+cd ai-web/backend
+. .venv/bin/activate
+pip install google-generativeai
+```
+"""
+        ),
+        md(
+            """## Step-by-step tasks
+### Step 1: Evaluation dataset stub
+A small evaluation dataset is stored for reproducibility.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+fixture_path = Path("ai-web/backend/app/eval_set.json")
+fixture_path.write_text('''[
+  {"prompt": "Summarize the project goals.", "expected": "A concise description is returned."},
+  {"prompt": "List backend components.", "expected": "FastAPI, FAISS, and Gemini proxy are noted."}
+]
+''')
+print("Evaluation dataset was created.")
+"""
+        ),
+        md(
+            """### Step 2: Metrics helper
+A helper is provided to time requests and count tokens.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+metrics_path = Path("ai-web/backend/app/metrics.py")
+metrics_path.write_text('''import hashlib
+import json
+import time
+from contextlib import contextmanager
+from typing import Dict
+
+TOKEN_LOG: Dict[str, int] = {}
+
+
+@contextmanager
+def track_latency(label: str):
+    start = time.perf_counter()
+    yield
+    duration = time.perf_counter() - start
+    print(f"{label} latency: {duration:.3f}s")
+
+
+def cache_key(prompt: str, tools: str) -> str:
+    payload = json.dumps({"prompt": prompt, "tools": tools}, sort_keys=True)
+    return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+
+
+def record_tokens(label: str, count: int):
+    TOKEN_LOG[label] = TOKEN_LOG.get(label, 0) + count
+''')
+print("Metrics helper was written.")
+"""
+        ),
+        md(
+            """### Step 3: Cache-enabled endpoint
+An evaluation endpoint is instrumented with caching and latency tracking.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+main_path = Path("ai-web/backend/app/main.py")
+text = main_path.read_text()
+if "evaluation_endpoint" not in text:
+    addition = '''
+from .metrics import cache_key, record_tokens, track_latency
+from .llm import chat as llm_chat
+
+CACHE = {}
+
+
+@app.post("/api/evaluate")
+def evaluation_endpoint(payload: dict):
+    prompt = payload.get("prompt", "")
+    tools = "".join(payload.get("tools", []))
+    key = cache_key(prompt, tools)
+    if key in CACHE:
+        return {"cached": True, "response": CACHE[key]}
+    with track_latency("evaluation"):
+        response = llm_chat([
+            {"role": "user", "content": prompt}
+        ])
+    record_tokens("evaluation", len(prompt.split()))
+    CACHE[key] = response
+    return {"cached": False, "response": response}
+'''
+    main_path.write_text(text.rstrip() + "\n" + addition)
+    print("Evaluation endpoint was appended.")
+else:
+    print("Evaluation endpoint already present.")
+"""
+        ),
+        acceptance(
+            "curl -X POST http://localhost:8000/api/evaluate -H 'Content-Type: application/json' -d '{\"prompt\":\"Summarize the project goals.\"}'",
+            "Responses indicate whether cache hits occurred and include evaluation output.",
+        ),
+        homework([
+            "Token accounting is integrated with external monitoring dashboards.",
+            "Additional evaluation prompts are composed for regression coverage.",
+        ]),
+    ],
+))
+
+labs.append((
+    "Lab11_Security_and_Hardening",
+    "Lab 11 · Security and Hardening",
+    [
+        md(
+            """## Objectives
+- Production CORS settings are tightened.
+- Payload limits and allow-lists are described.
+- SlowAPI rate limiting and prompt-injection checklists are provided.
+"""
+        ),
+        md(
+            """## What will be learned
+- Environment-specific CORS strategies are reinforced.
+- Input validation patterns are documented for safety.
+- Prompt-injection mitigations are rehearsed for RAG systems.
+"""
+        ),
+        md(
+            """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+cd ai-web/backend
+. .venv/bin/activate
+pip install slowapi
+```
+"""
+        ),
+        md(
+            """## Step-by-step tasks
+### Step 1: Security settings module
+Security utilities are collected for reuse.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+security_path = Path("ai-web/backend/app/security.py")
+security_path.write_text('''from slowapi import Limiter
+from slowapi.util import get_remote_address
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+SAFE_ORIGINS = ["https://example.com"]
+ALLOWED_FILES = {".txt", ".md"}
+limiter = Limiter(key_func=get_remote_address, default_limits=["60/minute"])
+
+
+def configure_security(app: FastAPI):
+    app.state.limiter = limiter
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=SAFE_ORIGINS,
+        allow_credentials=True,
+        allow_methods=["GET", "POST"],
+        allow_headers=["Content-Type", "Authorization"],
+    )
+''')
+print("Security module was written.")
+"""
+        ),
+        md(
+            """### Step 2: Payload guard
+A payload guard demonstrates enforcing limits and allow-lists.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+limits_path = Path("ai-web/backend/app/guards.py")
+limits_path.write_text('''from fastapi import HTTPException, UploadFile
+
+MAX_PAYLOAD_BYTES = 1024 * 1024
+ALLOWED_EXTENSIONS = {".txt", ".md", ".pdf"}
+
+
+def enforce_size(data: bytes):
+    if len(data) > MAX_PAYLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="Payload size limit was exceeded.")
+
+
+def enforce_extension(upload: UploadFile):
+    if not any(upload.filename.endswith(ext) for ext in ALLOWED_EXTENSIONS):
+        raise HTTPException(status_code=400, detail="File extension was not allowed.")
+''')
+print("Payload guard was documented.")
+"""
+        ),
+        md(
+            """### Step 3: Prompt-injection checklist
+A checklist is referenced for the RAG pipeline.
+"""
+        ),
+        md(
+            """A checklist is maintained:
+- External instructions are screened for deny-list phrases.
+- Citations are verified prior to response emission.
+- Sensitive tools are disabled when citations are missing.
+"""
+        ),
+        acceptance(
+            "curl http://localhost:8000/health",
+            "The hardened configuration preserves the health endpoint for monitoring.",
+        ),
+        homework([
+            "Rate limiting thresholds are tuned for production traffic patterns.",
+            "Security review notes are captured alongside deployment manifests.",
+        ]),
+    ],
+))
+
+labs.append((
+    "Lab12_Deployment_and_Docker",
+    "Lab 12 · Deployment and Docker",
+    [
+        md(
+            """## Objectives
+- A backend Dockerfile is drafted with environment configuration guidance.
+- A docker-compose sketch is recorded for local orchestration.
+- Frontend build and deployment checklists are enumerated.
+"""
+        ),
+        md(
+            """## What will be learned
+- Containerization patterns are reviewed for FastAPI and React.
+- Environment variable documentation is reinforced for deployment.
+- Health check considerations are summarized for operations.
+"""
+        ),
+        md(
+            """## Prerequisites & install
+The following commands are intended for local execution.
+
+```bash
+# Docker installation is confirmed locally
+docker --version
+docker compose version
+```
+"""
+        ),
+        md(
+            """## Step-by-step tasks
+### Step 1: Backend Dockerfile
+A Dockerfile is created for the FastAPI backend.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+dockerfile_path = Path("ai-web/backend/Dockerfile")
+dockerfile_path.write_text('''FROM python:3.11-slim
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . ./
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+''')
+print("Backend Dockerfile was created.")
+"""
+        ),
+        md(
+            """### Step 2: Compose sketch
+A docker-compose.yml sketch references backend and frontend builds.
+"""
+        ),
+        code(
+            """
+from pathlib import Path
+compose_path = Path("ai-web/docker-compose.yml")
+compose_path.write_text('''version: '3.9'
+services:
+  backend:
+    build: ./backend
+    environment:
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - REACT_APP_API_BASE=http://localhost:8000
+''')
+print("Compose sketch was drafted.")
+"""
+        ),
+        md(
+            """### Step 3: Deployment checklist
+Deployment steps are summarized for future reference.
+"""
+        ),
+        md(
+            """A deployment checklist is tracked:
+- Environment files are reviewed and populated without committing secrets.
+- docker compose build and docker compose up commands are executed locally for testing.
+- Health checks are observed via /health before promoting changes.
+- A demo script is outlined describing backend startup, frontend build, and proxy verification.
+"""
+        ),
+        acceptance(
+            "curl http://localhost:8000/health",
+            "Container builds expose the health endpoint for readiness checks.",
+        ),
+        homework([
+            "CI/CD pipeline steps are enumerated for automated deployments.",
+            "Frontend build artifacts are hosted on a static site provider checklist.",
+        ]),
+    ],
+))
+
+for name, title, cells in labs:
+    write_notebook(name, title, cells)
+
+print("All notebooks were generated under ai-web/labs.")


### PR DESCRIPTION
## Summary
- add a generator script that builds the 12 AI in Web Programming lab notebooks in passive voice with full scaffolding
- commit the generated notebooks under `ai-web/labs` with the required structure and lab-specific tasks
- document how to regenerate the notebooks via the helper script in a new README

## Testing
- python generate_ai_web_lab_notebooks.py

------
https://chatgpt.com/codex/tasks/task_e_68ca7dc7f0c48326ae5b3aa89a6d15af