### PR TITLE
Switch labs to Vite scaffolding and google-genai SDK

### DIFF
--- a/ai-web/labs/Lab01_FastAPI_Vite_and_Git.ipynb
+++ b/ai-web/labs/Lab01_FastAPI_Vite_and_Git.ipynb
@@ -1,0 +1,264 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "05daf237",
+   "metadata": {},
+   "source": [
+    "# Lab 01 · FastAPI, Vite, and Git\n",
+    "\n",
+    "*This lab notebook provides guided steps. All commands are intended for local execution.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94c27958",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- A FastAPI backend is scaffolded with health and echo routes.\n",
+    "- A Vite React frontend is outlined with modern tooling defaults.\n",
+    "- A Git repository is initialized with environment templates."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc6950ab",
+   "metadata": {},
+   "source": [
+    "## What will be learned\n",
+    "- The structure of a basic FastAPI service is reviewed.\n",
+    "- Development-time CORS settings are configured.\n",
+    "- Vite-powered React scaffolding steps are rehearsed.\n",
+    "- Git initialization practices are reinforced."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "423057b3",
+   "metadata": {},
+   "source": [
+    "## Prerequisites & install\n",
+    "The following commands are intended for local execution.\n",
+    "\n",
+    "```bash\n",
+    "python --version\n",
+    "node --version\n",
+    "npm --version\n",
+    "git --version\n",
+    "\n",
+    "# Backend environment preparation (local execution only)\n",
+    "cd ai-web/backend\n",
+    "python -m venv .venv\n",
+    "# Windows: .venv\\Scripts\\activate\n",
+    "# Unix/macOS:\n",
+    ". .venv/bin/activate\n",
+    "pip install fastapi uvicorn[standard] pydantic python-dotenv google-genai faiss-cpu numpy\n",
+    "\n",
+    "# Frontend creation (Vite React template)\n",
+    "cd ../../\n",
+    "npm create vite@latest frontend -- --template react\n",
+    "cd frontend\n",
+    "npm install\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd3bd902",
+   "metadata": {},
+   "source": [
+    "## Step-by-step tasks\n",
+    "Each step is executed locally so backend keys remain protected.\n",
+    "\n",
+    "### Step 1: Backend folder layout\n",
+    "A backend folder is created and populated with required files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d8d7f59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "base = Path(\"ai-web/backend\")\n",
+    "(base / \"app\").mkdir(parents=True, exist_ok=True)\n",
+    "(base / \"app\" / \"__init__.py\").write_text(\"\n",
+    "\")\n",
+    "(base / \".env.example\").write_text('# Environment variables (never commit real keys)\n",
+    "GEMINI_API_KEY=\n",
+    "')\n",
+    "(base / \"requirements.txt\").write_text('''fastapi\n",
+    "uvicorn[standard]\n",
+    "pydantic\n",
+    "python-dotenv\n",
+    "google-genai\n",
+    "faiss-cpu\n",
+    "numpy\n",
+    "''')\n",
+    "(base / \"app\" / \"main.py\").write_text('''from fastapi import FastAPI\n",
+    "from fastapi.middleware.cors import CORSMiddleware\n",
+    "from pydantic import BaseModel\n",
+    "\n",
+    "app = FastAPI()\n",
+    "app.add_middleware(\n",
+    "    CORSMiddleware,\n",
+    "    allow_origins=[\"http://localhost:5173\"],\n",
+    "    allow_methods=[\"*\"],\n",
+    "    allow_headers=[\"*\"],\n",
+    ")\n",
+    "\n",
+    "\n",
+    "class EchoIn(BaseModel):\n",
+    "    msg: str\n",
+    "\n",
+    "\n",
+    "@app.get(\"/health\")\n",
+    "def health():\n",
+    "    return {\"status\": \"ok\"}\n",
+    "\n",
+    "\n",
+    "@app.post(\"/echo\")\n",
+    "def echo(payload: EchoIn):\n",
+    "    return {\"msg\": payload.msg}\n",
+    "''')\n",
+    "print(\"Backend scaffold was written under ai-web/backend.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96e9acfb",
+   "metadata": {},
+   "source": [
+    "### Step 2: Frontend placeholders\n",
+    "Frontend placeholders are positioned so Vite React components (`src/App.jsx`, `src/main.jsx`) can be customized while the generated `vite.config.js` continues to manage dev server defaults."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c7a6f30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "src = Path(\"ai-web/frontend/src\")\n",
+    "(src / \"lib\").mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "(src / \"lib\" / \"api.js\").write_text('''const BASE = import.meta.env.VITE_API_BASE || \"http://localhost:8000\";\n",
+    "\n",
+    "export async function post(path, body) {\n",
+    "  const res = await fetch(`${BASE}${path}`, {\n",
+    "    method: 'POST',\n",
+    "    headers: { 'Content-Type': 'application/json' },\n",
+    "    body: JSON.stringify(body)\n",
+    "  });\n",
+    "  if (!res.ok) {\n",
+    "    throw new Error(`HTTP ${res.status}`);\n",
+    "  }\n",
+    "  return res.json();\n",
+    "}\n",
+    "''')\n",
+    "(src / \"App.jsx\").write_text('''import { useState } from 'react';\n",
+    "import { post } from './lib/api';\n",
+    "\n",
+    "function App() {\n",
+    "  const [msg, setMsg] = useState('hello');\n",
+    "  const [response, setResponse] = useState('');\n",
+    "  const [loading, setLoading] = useState(false);\n",
+    "  const [error, setError] = useState('');\n",
+    "\n",
+    "  async function handleSend() {\n",
+    "    setLoading(true);\n",
+    "    setError('');\n",
+    "    try {\n",
+    "      const json = await post('/echo', { msg });\n",
+    "      setResponse(json.msg);\n",
+    "    } catch (err) {\n",
+    "      setError(String(err));\n",
+    "    } finally {\n",
+    "      setLoading(false);\n",
+    "    }\n",
+    "  }\n",
+    "\n",
+    "  return (\n",
+    "    <main style={{ padding: 24 }}>\n",
+    "      <h1>Lab 1 — Echo demo</h1>\n",
+    "      <input value={msg} onChange={(event) => setMsg(event.target.value)} />\n",
+    "      <button onClick={handleSend} disabled={loading}>Send</button>\n",
+    "      {loading && <p>Loading…</p>}\n",
+    "      {error && <p style={{ color: 'red' }}>{error}</p>}\n",
+    "      <pre>{response}</pre>\n",
+    "    </main>\n",
+    "  );\n",
+    "}\n",
+    "\n",
+    "export default App;\n",
+    "''')\n",
+    "(src / \"main.jsx\").write_text('''import React from 'react';\n",
+    "import ReactDOM from 'react-dom/client';\n",
+    "import App from './App.jsx';\n",
+    "\n",
+    "ReactDOM.createRoot(document.getElementById('root')).render(\n",
+    "  <React.StrictMode>\n",
+    "    <App />\n",
+    "  </React.StrictMode>,\n",
+    ");\n",
+    "''')\n",
+    "print(\"Frontend placeholders were written under ai-web/frontend/src.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f715c46",
+   "metadata": {},
+   "source": [
+    "### Step 3: Git initialization\n",
+    "Git is initialized locally so changes can be tracked."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "951fc337",
+   "metadata": {},
+   "source": [
+    "```bash\n",
+    "cd ai-web\n",
+    "git init\n",
+    "git add .\n",
+    "git commit -m \"Lab 1 scaffold\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5e0b4cb",
+   "metadata": {},
+   "source": [
+    "## Validation / acceptance checks\n",
+    "```bash\n",
+    "# locally\n",
+    "curl http://localhost:8000/health\n",
+    "curl -X POST http://localhost:8000/echo -H 'Content-Type: application/json' -d '{\"msg\":\"hello\"}'\n",
+    "```\n",
+    "- HTTP 200 responses include status \"ok\" and the echoed payload.\n",
+    "- React development mode shows the described UI state without console errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "197c568a",
+   "metadata": {},
+   "source": [
+    "## Homework / extensions\n",
+    "- A README entry is expanded to document backend and frontend start commands.\n",
+    "- A GitHub repository is connected for remote backups."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai-web/labs/Lab02_HTTP_Forms_and_Retry.ipynb
+++ b/ai-web/labs/Lab02_HTTP_Forms_and_Retry.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a0af8698",
+   "id": "c6402875",
    "metadata": {},
    "source": [
     "# Lab 02 · HTTP Forms and Retry\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f5996cd",
+   "id": "0f49bc88",
    "metadata": {},
    "source": [
     "## Objectives\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b95786a",
+   "id": "86bd98d1",
    "metadata": {},
    "source": [
     "## What will be learned\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4334fb15",
+   "id": "36018592",
    "metadata": {},
    "source": [
     "## Prerequisites & install\n",
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14db1484",
+   "id": "85d7ef5f",
    "metadata": {},
    "source": [
     "## Step-by-step tasks\n",
@@ -59,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25f1e0b2",
+   "id": "530801d0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,22 +84,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "518be421",
+   "id": "70dc57ad",
    "metadata": {},
    "source": [
     "### Step 2: Form integration\n",
-    "App.js is updated so the retry helper wraps the echo request and error states remain friendly."
+    "App.jsx is updated so the retry helper wraps the echo request and error states remain friendly."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b61f4b6e",
+   "id": "59c4d585",
    "metadata": {},
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
-    "app_js = Path(\"ai-web/frontend/src/App.js\")\n",
+    "app_js = Path(\"ai-web/frontend/src/App.jsx\")\n",
     "text = app_js.read_text()\n",
     "if \"withRetry\" not in text:\n",
     "    text = text.replace(\n",
@@ -118,12 +118,12 @@
     "        \"setError('A temporary issue was encountered. Please try again.');\",\n",
     "    )\n",
     "app_js.write_text(text)\n",
-    "print(\"App.js was adjusted for retry and friendly errors.\")"
+    "print(\"App.jsx was adjusted for retry and friendly errors.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cd67b660",
+   "id": "fa9a017e",
    "metadata": {},
    "source": [
     "## Validation / acceptance checks\n",
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "637adf6b",
+   "id": "4c74384a",
    "metadata": {},
    "source": [
     "## Homework / extensions\n",
@@ -146,17 +146,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "mitocluster",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.11.5"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/ai-web/labs/Lab03_Gemini_Proxy_Chat.ipynb
+++ b/ai-web/labs/Lab03_Gemini_Proxy_Chat.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "33eeeba7",
+   "id": "017bf5e3",
    "metadata": {},
    "source": [
     "# Lab 03 · Gemini Proxy Chat\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47de6f88",
+   "id": "cfec0a65",
    "metadata": {},
    "source": [
     "## Objectives\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef4a0618",
+   "id": "598f0d61",
    "metadata": {},
    "source": [
     "## What will be learned\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "373bf681",
+   "id": "5059f46d",
    "metadata": {},
    "source": [
     "## Prerequisites & install\n",
@@ -43,13 +43,13 @@
     "```bash\n",
     "cd ai-web/backend\n",
     ". .venv/bin/activate\n",
-    "pip install google-generativeai\n",
+    "pip install google-genai\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "07a89a5a",
+   "id": "5db9946c",
    "metadata": {},
    "source": [
     "## Step-by-step tasks\n",
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e02eb74",
+   "id": "a7bc0fed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,18 +68,20 @@
     "module = Path(\"ai-web/backend/app/llm.py\")\n",
     "module.parent.mkdir(parents=True, exist_ok=True)\n",
     "module.write_text('''import os\n",
-    "from typing import List, Dict\n",
+    "from typing import Dict, List, Any\n",
     "\n",
-    "import google.generativeai as genai\n",
+    "from google import genai\n",
     "\n",
     "\n",
-    "def chat(messages: List[Dict[str, str]]) -> str:\n",
+    "def chat(messages: List[Dict[str, Any]]) -> str:\n",
     "  api_key = os.environ.get('GEMINI_API_KEY', '')\n",
     "  if not api_key:\n",
     "    raise RuntimeError('A backend API key is required.')\n",
-    "  genai.configure(api_key=api_key)\n",
-    "  model = genai.GenerativeModel('gemini-1.5-flash')\n",
-    "  response = model.generate_content(messages)\n",
+    "  client = genai.Client(api_key=api_key)\n",
+    "  response = client.models.generate_content(\n",
+    "      model=\"gemini-1.5-flash\",\n",
+    "      contents=messages,\n",
+    "  )\n",
     "  return response.text\n",
     "''')\n",
     "print(\"Gemini helper was written.\")"
@@ -87,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "210a4d10",
+   "id": "c6298a58",
    "metadata": {},
    "source": [
     "### Step 2: FastAPI route update\n",
@@ -97,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "550f0ebb",
+   "id": "fac05130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,22 +139,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd5dc6d4",
+   "id": "3524459f",
    "metadata": {},
    "source": [
     "### Step 3: React chat surface\n",
-    "A lightweight chat component is appended to App.js so the proxy is exercised."
+    "A lightweight chat component is appended to App.jsx so the proxy is exercised."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "168ba811",
+   "id": "fb9ccfe8",
    "metadata": {},
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
-    "app_js = Path(\"ai-web/frontend/src/App.js\")\n",
+    "app_js = Path(\"ai-web/frontend/src/App.jsx\")\n",
     "app_js.write_text('''import React, { useState } from 'react';\n",
     "import { post } from './lib/api';\n",
     "import { withRetry } from './lib/retry';\n",
@@ -215,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2c989a1",
+   "id": "361425b3",
    "metadata": {},
    "source": [
     "## Validation / acceptance checks\n",
@@ -229,7 +231,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9be9d3cf",
+   "id": "94cc9759",
    "metadata": {},
    "source": [
     "## Homework / extensions\n",

--- a/ai-web/labs/Lab04_Structured_JSON_and_Validation.ipynb
+++ b/ai-web/labs/Lab04_Structured_JSON_and_Validation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4d537063",
+   "id": "5fe6ea29",
    "metadata": {},
    "source": [
     "# Lab 04 · Structured JSON and Validation\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "696a6db3",
+   "id": "58a1c471",
    "metadata": {},
    "source": [
     "## Objectives\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b095e13f",
+   "id": "40081e76",
    "metadata": {},
    "source": [
     "## What will be learned\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de2a0237",
+   "id": "8b77578d",
    "metadata": {},
    "source": [
     "## Prerequisites & install\n",
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "011e2425",
+   "id": "90da9a05",
    "metadata": {},
    "source": [
     "## Step-by-step tasks\n",
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6e172ad",
+   "id": "e38722c6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "233bd136",
+   "id": "d6c1d15c",
    "metadata": {},
    "source": [
     "### Step 2: API exposure\n",
@@ -108,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee6da1d7",
+   "id": "b1045bf3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d89179d6",
+   "id": "b256dc8f",
    "metadata": {},
    "source": [
     "## Validation / acceptance checks\n",
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df56a06e",
+   "id": "5923461e",
    "metadata": {},
    "source": [
     "## Homework / extensions\n",

--- a/ai-web/labs/Lab05_Simple_Agent_and_Tools.ipynb
+++ b/ai-web/labs/Lab05_Simple_Agent_and_Tools.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "70fdff7b",
+   "id": "5513ce4d",
    "metadata": {},
    "source": [
     "# Lab 05 · Simple Agent and Tools\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3b99789",
+   "id": "c3ea526d",
    "metadata": {},
    "source": [
     "## Objectives\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "317078da",
+   "id": "616b63cd",
    "metadata": {},
    "source": [
     "## What will be learned\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e5cb507",
+   "id": "00439ff0",
    "metadata": {},
    "source": [
     "## Prerequisites & install\n",
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28bd09b6",
+   "id": "88e2a4c7",
    "metadata": {},
    "source": [
     "## Step-by-step tasks\n",
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7623303a",
+   "id": "2bacb20e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51574cb5",
+   "id": "49de0212",
    "metadata": {},
    "source": [
     "### Step 2: Agent loop outline\n",
@@ -105,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9174f9f5",
+   "id": "8dd00761",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eaf65da0",
+   "id": "396b2fc4",
    "metadata": {},
    "source": [
     "### Step 3: Endpoint exposure\n",
@@ -147,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53ceed7d",
+   "id": "8cf9bb99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "611752a4",
+   "id": "41e43b76",
    "metadata": {},
    "source": [
     "## Validation / acceptance checks\n",
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "616ef1af",
+   "id": "ff835e52",
    "metadata": {},
    "source": [
     "## Homework / extensions\n",

--- a/ai-web/labs/Lab06_Embeddings_and_FAISS.ipynb
+++ b/ai-web/labs/Lab06_Embeddings_and_FAISS.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "eafe495a",
+   "id": "23498c17",
    "metadata": {},
    "source": [
     "# Lab 06 · Embeddings and FAISS\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfea26d0",
+   "id": "42a1e166",
    "metadata": {},
    "source": [
     "## Objectives\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0390110",
+   "id": "3451f2b6",
    "metadata": {},
    "source": [
     "## What will be learned\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7eb68ac3",
+   "id": "a5d6bc2d",
    "metadata": {},
    "source": [
     "## Prerequisites & install\n",
@@ -43,13 +43,13 @@
     "```bash\n",
     "cd ai-web/backend\n",
     ". .venv/bin/activate\n",
-    "pip install faiss-cpu google-generativeai numpy\n",
+    "pip install faiss-cpu google-genai numpy\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b6f4be53",
+   "id": "d7da0e81",
    "metadata": {},
    "source": [
     "## Step-by-step tasks\n",
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e83f8b5",
+   "id": "25f9d48c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +71,7 @@
     "from pathlib import Path\n",
     "from typing import List, Tuple\n",
     "\n",
-    "import google.generativeai as genai\n",
+    "from google import genai\n",
     "import numpy as np\n",
     "import faiss\n",
     "\n",
@@ -82,18 +82,31 @@
     "META_FILE = DATA_DIR / \"metadata.json\"\n",
     "\n",
     "\n",
+    "def _client() -> genai.Client:\n",
+    "  api_key = os.environ.get('GEMINI_API_KEY', '')\n",
+    "  if not api_key:\n",
+    "    raise RuntimeError('A backend API key is required for embeddings.')\n",
+    "  return genai.Client(api_key=api_key)\n",
+    "\n",
+    "\n",
+    "def _text_content(text: str) -> dict:\n",
+    "  return {\"parts\": [{\"text\": text}]}\n",
+    "\n",
+    "\n",
     "def chunk_text(text: str, size: int = 400) -> List[str]:\n",
     "  return [text[i:i + size] for i in range(0, len(text), size) if text[i:i + size].strip()]\n",
     "\n",
     "\n",
     "def embed_chunks(chunks: List[str]) -> np.ndarray:\n",
-    "  api_key = os.environ.get('GEMINI_API_KEY', '')\n",
-    "  if not api_key:\n",
-    "    raise RuntimeError('A backend API key is required for embeddings.')\n",
-    "  genai.configure(api_key=api_key)\n",
-    "  model = genai.EmbeddingModel(model_name='text-embedding-004')\n",
-    "  vectors = model.embed_content([{ \"title\": f\"Chunk {idx}\", \"content\": chunk } for idx, chunk in enumerate(chunks)])\n",
-    "  return np.array([item.values for item in vectors], dtype=np.float32)\n",
+    "  client = _client()\n",
+    "  response = client.models.embed_content(\n",
+    "      model='text-embedding-004',\n",
+    "      contents=[_text_content(chunk) for chunk in chunks],\n",
+    "  )\n",
+    "  embeddings = response.embeddings or []\n",
+    "  if not embeddings:\n",
+    "    raise RuntimeError('No embeddings were returned from the Gemini API.')\n",
+    "  return np.array([item.values for item in embeddings], dtype=np.float32)\n",
     "\n",
     "\n",
     "def save_index(chunks: List[str], vectors: np.ndarray) -> None:\n",
@@ -122,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0af0c4c5",
+   "id": "849f5f29",
    "metadata": {},
    "source": [
     "### Step 2: Index builder cell\n",
@@ -132,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d51ca9ab",
+   "id": "54f14a41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7f13eeb",
+   "id": "62b1be89",
    "metadata": {},
    "source": [
     "### Step 3: Search endpoint\n",
@@ -164,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dafa4a26",
+   "id": "a2ea384e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49212d07",
+   "id": "b44c0e0d",
    "metadata": {},
    "source": [
     "## Validation / acceptance checks\n",
@@ -205,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28f7d673",
+   "id": "4fbe9259",
    "metadata": {},
    "source": [
     "## Homework / extensions\n",

--- a/ai-web/labs/Lab07_RAG_with_Citations.ipynb
+++ b/ai-web/labs/Lab07_RAG_with_Citations.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ae2f02c9",
+   "id": "f0441c61",
    "metadata": {},
    "source": [
     "# Lab 07 · RAG with Citations\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f41ba182",
+   "id": "b68688af",
    "metadata": {},
    "source": [
     "## Objectives\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8345e75c",
+   "id": "a4a0b43b",
    "metadata": {},
    "source": [
     "## What will be learned\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38b38581",
+   "id": "fa8be19a",
    "metadata": {},
    "source": [
     "## Prerequisites & install\n",
@@ -43,13 +43,13 @@
     "```bash\n",
     "cd ai-web/backend\n",
     ". .venv/bin/activate\n",
-    "pip install google-generativeai\n",
+    "pip install google-genai\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e5781869",
+   "id": "cbbe60d5",
    "metadata": {},
    "source": [
     "## Step-by-step tasks\n",
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "973dad3a",
+   "id": "ba2f28b7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "879149c5",
+   "id": "854f0381",
    "metadata": {},
    "source": [
     "### Step 2: Endpoint exposure\n",
@@ -101,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e0aacec",
+   "id": "70160a31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "720687ad",
+   "id": "b9b388c7",
    "metadata": {},
    "source": [
     "## Validation / acceptance checks\n",
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "857f2b98",
+   "id": "6e287521",
    "metadata": {},
    "source": [
     "## Homework / extensions\n",

--- a/ai-web/labs/Lab08_TensorFlowJS_Browser_Inference.ipynb
+++ b/ai-web/labs/Lab08_TensorFlowJS_Browser_Inference.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6722c9de",
+   "id": "fe2928d5",
    "metadata": {},
    "source": [
     "# Lab 08 · TensorFlow.js Browser Inference\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0148de7a",
+   "id": "51e4e9ec",
    "metadata": {},
    "source": [
     "## Objectives\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "179764da",
+   "id": "f1674f6b",
    "metadata": {},
    "source": [
     "## What will be learned\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9f936c1",
+   "id": "2c52c26b",
    "metadata": {},
    "source": [
     "## Prerequisites & install\n",
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "123c3413",
+   "id": "b6b6a3d6",
    "metadata": {},
    "source": [
     "## Step-by-step tasks\n",
@@ -59,12 +59,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad2bb2e4",
+   "id": "73905c64",
    "metadata": {},
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
-    "app_js = Path(\"ai-web/frontend/src/App.js\")\n",
+    "app_js = Path(\"ai-web/frontend/src/App.jsx\")\n",
     "app_js.write_text('''import React, { useEffect, useRef, useState } from 'react';\n",
     "import * as cocoSsd from '@tensorflow-models/coco-ssd';\n",
     "import '@tensorflow/tfjs';\n",
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a60d5bf",
+   "id": "ac34d6fc",
    "metadata": {},
    "source": [
     "## Validation / acceptance checks\n",
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a46dbef",
+   "id": "7153cc24",
    "metadata": {},
    "source": [
     "## Homework / extensions\n",

--- a/ai-web/labs/Lab09_Agent_Memory_SQLite.ipynb
+++ b/ai-web/labs/Lab09_Agent_Memory_SQLite.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6eb6fdb4",
+   "id": "836ea0d7",
    "metadata": {},
    "source": [
     "# Lab 09 · Agent Memory with SQLite\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72adcddf",
+   "id": "be9b1c5b",
    "metadata": {},
    "source": [
     "## Objectives\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c137e4bf",
+   "id": "cbb54e43",
    "metadata": {},
    "source": [
     "## What will be learned\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a451c225",
+   "id": "86a6e09e",
    "metadata": {},
    "source": [
     "## Prerequisites & install\n",
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4dc7091f",
+   "id": "72eae7db",
    "metadata": {},
    "source": [
     "## Step-by-step tasks\n",
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e00b9006",
+   "id": "02d94c8e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c69356ca",
+   "id": "a052438c",
    "metadata": {},
    "source": [
     "### Step 2: Repository helper\n",
@@ -102,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1dc250a",
+   "id": "0933406b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5776f80",
+   "id": "dc89229c",
    "metadata": {},
    "source": [
     "### Step 3: Summarization plan\n",
@@ -161,7 +161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9cbf2648",
+   "id": "341c6589",
    "metadata": {},
    "source": [
     "A periodic job is proposed in which conversations are summarized into the memories table. The job is scheduled after a session surpasses a message threshold. A placeholder function is positioned so later labs can hook in summarization calls."
@@ -170,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45302bbe",
+   "id": "9216ac24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f960332",
+   "id": "b7d4f3cb",
    "metadata": {},
    "source": [
     "## Validation / acceptance checks\n",
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "101c0a03",
+   "id": "08b34f04",
    "metadata": {},
    "source": [
     "## Homework / extensions\n",

--- a/ai-web/labs/Lab10_Evaluation_Latency_Cache.ipynb
+++ b/ai-web/labs/Lab10_Evaluation_Latency_Cache.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "bf73da21",
+   "id": "58f3af1c",
    "metadata": {},
    "source": [
     "# Lab 10 · Evaluation, Latency, and Cache\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2d9c448",
+   "id": "4ddcd87f",
    "metadata": {},
    "source": [
     "## Objectives\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f1a900f",
+   "id": "aa37ba39",
    "metadata": {},
    "source": [
     "## What will be learned\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c90538b0",
+   "id": "e717ec4b",
    "metadata": {},
    "source": [
     "## Prerequisites & install\n",
@@ -43,13 +43,13 @@
     "```bash\n",
     "cd ai-web/backend\n",
     ". .venv/bin/activate\n",
-    "pip install google-generativeai\n",
+    "pip install google-genai\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8b1b3a65",
+   "id": "1592d318",
    "metadata": {},
    "source": [
     "## Step-by-step tasks\n",
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88cdfeee",
+   "id": "ca8263a9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "939f65f1",
+   "id": "a700bdc7",
    "metadata": {},
    "source": [
     "### Step 2: Metrics helper\n",
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "548cd4a6",
+   "id": "048ef914",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fca8da2",
+   "id": "9f273dde",
    "metadata": {},
    "source": [
     "### Step 3: Cache-enabled endpoint\n",
@@ -132,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb6b7a03",
+   "id": "ad8cc719",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0bb4d25c",
+   "id": "3c24aa74",
    "metadata": {},
    "source": [
     "## Validation / acceptance checks\n",
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10b8ecfd",
+   "id": "518080e1",
    "metadata": {},
    "source": [
     "## Homework / extensions\n",

--- a/ai-web/labs/Lab11_Security_and_Hardening.ipynb
+++ b/ai-web/labs/Lab11_Security_and_Hardening.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "64613843",
+   "id": "d2771490",
    "metadata": {},
    "source": [
     "# Lab 11 · Security and Hardening\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59a1b763",
+   "id": "02397a5c",
    "metadata": {},
    "source": [
     "## Objectives\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21c427cc",
+   "id": "0cf8feb0",
    "metadata": {},
    "source": [
     "## What will be learned\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e688540",
+   "id": "08d0fd32",
    "metadata": {},
    "source": [
     "## Prerequisites & install\n",
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c58254e",
+   "id": "b63f9908",
    "metadata": {},
    "source": [
     "## Step-by-step tasks\n",
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c71592e",
+   "id": "3cea2a26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23c79e95",
+   "id": "0d84a6c4",
    "metadata": {},
    "source": [
     "### Step 2: Payload guard\n",
@@ -101,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83f47ef0",
+   "id": "efc3cef1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f31ad787",
+   "id": "cb0dcd85",
    "metadata": {},
    "source": [
     "### Step 3: Prompt-injection checklist\n",
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5d32128",
+   "id": "18f8ed24",
    "metadata": {},
    "source": [
     "A checklist is maintained:\n",
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cc51d21",
+   "id": "b62feeb7",
    "metadata": {},
    "source": [
     "## Validation / acceptance checks\n",
@@ -161,7 +161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecd1a035",
+   "id": "ea497b94",
    "metadata": {},
    "source": [
     "## Homework / extensions\n",

--- a/ai-web/labs/Lab12_Deployment_and_Docker.ipynb
+++ b/ai-web/labs/Lab12_Deployment_and_Docker.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5814107b",
+   "id": "008d9f0e",
    "metadata": {},
    "source": [
     "# Lab 12 · Deployment and Docker\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "863f7d58",
+   "id": "9a8754ac",
    "metadata": {},
    "source": [
     "## Objectives\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4da72b7",
+   "id": "f80e0866",
    "metadata": {},
    "source": [
     "## What will be learned\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66f15c6a",
+   "id": "d35523dc",
    "metadata": {},
    "source": [
     "## Prerequisites & install\n",
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0dd9505",
+   "id": "e64d3630",
    "metadata": {},
    "source": [
     "## Step-by-step tasks\n",
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80026770",
+   "id": "d707aff0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "793c839e",
+   "id": "b959578d",
    "metadata": {},
    "source": [
     "### Step 2: Compose sketch\n",
@@ -90,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d54eb45e",
+   "id": "11282619",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,16 +107,16 @@
     "  frontend:\n",
     "    build: ./frontend\n",
     "    ports:\n",
-    "      - \"3000:3000\"\n",
+    "      - \"5173:5173\"\n",
     "    environment:\n",
-    "      - REACT_APP_API_BASE=http://localhost:8000\n",
+    "      - VITE_API_BASE=http://localhost:8000\n",
     "''')\n",
     "print(\"Compose sketch was drafted.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1a74f075",
+   "id": "5f1dc53f",
    "metadata": {},
    "source": [
     "### Step 3: Deployment checklist\n",
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70cb67ea",
+   "id": "fcca6ed8",
    "metadata": {},
    "source": [
     "A deployment checklist is tracked:\n",
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c61db12",
+   "id": "b82b2b57",
    "metadata": {},
    "source": [
     "## Validation / acceptance checks\n",
@@ -151,7 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e83443c",
+   "id": "b294841d",
    "metadata": {},
    "source": [
     "## Homework / extensions\n",


### PR DESCRIPTION
## Summary
- replace the Lab 01 scaffolding with a Vite-based React workflow, including App.jsx/main.jsx placeholders and VITE_* environment variables
- migrate generated backend helpers and prose to the modern google-genai client and update the FAISS vector utility accordingly
- regenerate all lab notebooks so the new tooling, ports, and environment variable names are reflected throughout

## Testing
- python generate_ai_web_lab_notebooks.py

------
https://chatgpt.com/codex/tasks/task_e_68cef2ca53d08326bfe7ed4364b7758a