### PR TITLE
Update Lab 1 prerequisites for Vite frontend

### DIFF
--- a/ai-web/labs/Lab01_FastAPI_Vite_and_Git.ipynb
+++ b/ai-web/labs/Lab01_FastAPI_Vite_and_Git.ipynb
@@ -5,7 +5,7 @@
    "id": "05daf237",
    "metadata": {},
    "source": [
-    "# Lab 01 · FastAPI, Vite, and Git\n",
+    "# Lab 01 \u00b7 FastAPI, Vite, and Git\n",
     "\n",
     "*This lab notebook provides guided steps. All commands are intended for local execution.*"
    ]
@@ -38,15 +38,16 @@
    "id": "423057b3",
    "metadata": {},
    "source": [
+    "\n",
     "## Prerequisites & install\n",
     "The following tools are needed for this lab. Install them locally and keep all project-specific environments inside this repository so nothing leaks into the rest of your system.\n",
     "\n",
     "| Tool | Why we use it in this lab | Download or docs |\n",
     "| --- | --- | --- |\n",
     "| Python 3.10+ | Runs the FastAPI backend and virtual environment tooling. | [python.org/downloads](https://www.python.org/downloads/) |\n",
-    "| Node.js & npm | Provides the JavaScript runtime and package manager required by Create React App. | [nodejs.org](https://nodejs.org/) |\n",
+    "| Node.js & npm | Provide the JavaScript runtime and package manager that power the Vite development server and build steps. | [nodejs.org](https://nodejs.org/) |\n",
     "| Git | Tracks changes and enables pushing your work to GitHub. | [git-scm.com/downloads](https://git-scm.com/downloads) |\n",
-    "| Create React App (npx) | Bootstraps the React frontend scaffold used in the lab. | [create-react-app.dev](https://create-react-app.dev/docs/getting-started/) |\n",
+    "| Vite (npm create) | Bootstraps the React + Vite frontend scaffold used in the lab. | [vitejs.dev/guide](https://vitejs.dev/guide/) |\n",
     "| FastAPI | Python web framework for building the backend API. | [fastapi.tiangolo.com](https://fastapi.tiangolo.com/) |\n",
     "| Uvicorn | ASGI server that runs the FastAPI app locally. | [www.uvicorn.org](https://www.uvicorn.org/) |\n",
     "| Pydantic | Validates request/response models in the FastAPI backend. | [docs.pydantic.dev](https://docs.pydantic.dev/) |\n",
@@ -55,7 +56,7 @@
     "| faiss-cpu | Provides vector similarity search utilities used by the AI features. | [pypi.org/project/faiss-cpu](https://pypi.org/project/faiss-cpu/) |\n",
     "| numpy | Supports numerical operations required by FAISS and data processing. | [numpy.org](https://numpy.org/install/) |\n",
     "\n",
-    "Before installing dependencies, change into `ai-web/backend`, create (if needed) and activate the `.venv` virtual environment there, and scaffold the React app inside `ai-web/frontend` so every dependency stays scoped to this project folder.\n",
+    "Before installing dependencies, change into `ai-web/backend`, create (if needed) and activate the `.venv` virtual environment there, and scaffold the React app inside `ai-web/frontend` with Vite so every dependency stays scoped to this project folder.\n",
     "\n",
     "```bash\n",
     "python --version\n",
@@ -71,12 +72,13 @@
     ". .venv/bin/activate\n",
     "pip install fastapi uvicorn[standard] pydantic python-dotenv google-generativeai faiss-cpu numpy\n",
     "\n",
-    "# Frontend creation (Create React App; no Vite)\n",
-    "cd ../../\n",
-    "npx create-react-app frontend\n",
+    "# Frontend creation (Vite + React)\n",
+    "cd ../..\n",
+    "cd ai-web\n",
+    "npm create vite@latest frontend -- --template react\n",
     "cd frontend\n",
     "npm install\n",
-    "```"
+    "```\n"
    ]
   },
   {
@@ -201,10 +203,10 @@
     "\n",
     "  return (\n",
     "    <main style={{ padding: 24 }}>\n",
-    "      <h1>Lab 1 — Echo demo</h1>\n",
+    "      <h1>Lab 1 \u2014 Echo demo</h1>\n",
     "      <input value={msg} onChange={(event) => setMsg(event.target.value)} />\n",
     "      <button onClick={handleSend} disabled={loading}>Send</button>\n",
-    "      {loading && <p>Loading…</p>}\n",
+    "      {loading && <p>Loading\u2026</p>}\n",
     "      {error && <p style={{ color: 'red' }}>{error}</p>}\n",
     "      <pre>{response}</pre>\n",
     "    </main>\n",


### PR DESCRIPTION
## Summary
- update the Lab 1 prerequisites table to reference the Vite toolchain instead of Create React App
- refresh the setup instructions to scaffold the frontend with `npm create vite@latest`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cefbb4134c83268284d6d235d5237a