### PR TITLE
Enable backend auto-reload in development

### DIFF
--- a/ai-web/backend/Dockerfile
+++ b/ai-web/backend/Dockerfile
@@ -10,4 +10,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app ./app
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]


### PR DESCRIPTION
## Summary
- add Uvicorn's `--reload` flag to the backend Dockerfile so code changes trigger hot reloads during development

## Testing
- not run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68e15349e41c8326b133ac67b442d14e