### PR TITLE
Modularize echo feature across backend and frontend

### DIFF
--- a/ai-web/backend/app/main.py
+++ b/ai-web/backend/app/main.py
@@ -1,61 +1,28 @@
-"""FastAPI backend powering the lab exercises.
-
-This lightweight service exposes a health check and an echo endpoint that the
-frontend labs call during development. CORS middleware is configured so the
-Vite dev server can reach the API from a different origin while students test
-their work locally.
-"""
+"""FastAPI application entry point used by the lab backend container."""
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+
+from app.routers.echo import router as echo_router
 
 # Load environment variables from a local .env file when present so the
 # application picks up credentials configured for the labs.
 load_dotenv()
 
-app = FastAPI()  # Entry point creation
+app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],  # Permit the local Vite dev server.
+    allow_origins=["http://localhost:5173"],
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
-
-# Track transient failure counts per client to simulate flaky behavior.
-_flaky_attempts: dict[str, int] = {}
-
-
-class EchoIn(BaseModel):
-    """Payload schema for `/echo`, carrying the text entered in the labs."""
-    msg: str
+app.include_router(echo_router)
 
 
 @app.get("/health")
-def health():
+def health() -> dict[str, str]:
     """Report service status for lab curl checks and container health probes."""
+
     return {"status": "ok"}
-
-
-@app.post("/echo")
-def echo(payload: EchoIn):
-    """Echo the provided message so students can verify request/response flows."""
-    return {"msg": payload.msg}
-
-
-@app.post("/flaky-echo")
-def flaky_echo(payload: EchoIn, request: Request, failures: int = 1):
-    """Simulate transient failures before eventually echoing the payload."""
-
-    client_host = request.client.host if request.client else "unknown"
-    key = f"{client_host}:{failures}"
-    seen = _flaky_attempts.get(key, 0)
-
-    if seen < failures:
-        _flaky_attempts[key] = seen + 1
-        raise HTTPException(status_code=503, detail="Simulated transient failure")
-
-    _flaky_attempts[key] = 0
-    return {"msg": payload.msg, "attempts": seen + 1}

--- a/ai-web/backend/app/routers/__init__.py
+++ b/ai-web/backend/app/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Router modules for the lab backend."""

--- a/ai-web/backend/app/routers/echo.py
+++ b/ai-web/backend/app/routers/echo.py
@@ -1,0 +1,43 @@
+"""Echo-related API routes used throughout the web programming labs.
+
+The router exposes the lab's simple `/echo` endpoint alongside a `/flaky-echo`
+variant that intentionally fails a configurable number of times.  Keeping these
+routes in a dedicated module mirrors the folder structure that students build in
+Lab 01, where routers, services, and schemas live in their own packages.
+"""
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from app.services.echo import EchoServiceError, get_echo_payload, get_flaky_echo_payload
+
+router = APIRouter(tags=["echo"])
+
+
+class EchoIn(BaseModel):
+    """Pydantic model describing the request body submitted from the frontend."""
+
+    msg: str
+
+
+@router.post("/echo")
+def echo(payload: EchoIn) -> dict[str, str]:
+    """Return the payload unchanged so students can verify request plumbing."""
+
+    return get_echo_payload(payload.msg)
+
+
+@router.post("/flaky-echo")
+def flaky_echo(payload: EchoIn, request: Request, failures: int = 1) -> dict[str, int | str]:
+    """Simulate transient failures before eventually returning the echoed message.
+
+    The router delegates the retry tracking to the service layer so the example
+    mirrors the lab notes that encourage thin route handlers.
+    """
+
+    client_host = request.client.host if request.client else "unknown"
+
+    try:
+        return get_flaky_echo_payload(payload.msg, client_host, failures)
+    except EchoServiceError as exc:  # Translate the domain error into an HTTP error.
+        raise HTTPException(status_code=503, detail=str(exc)) from exc

--- a/ai-web/backend/app/services/__init__.py
+++ b/ai-web/backend/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service-layer helpers for FastAPI routers used in the labs."""

--- a/ai-web/backend/app/services/echo.py
+++ b/ai-web/backend/app/services/echo.py
@@ -1,0 +1,57 @@
+"""Service helpers containing the business logic for the echo endpoints.
+
+The routers import these helpers so that the FastAPI layer remains focused on
+HTTP details while the service layer owns the stateful retry simulation.  This
+matches the separation of concerns demonstrated in the accompanying lab
+notebooks and gives instructors a concrete example to reference in class.
+"""
+
+from dataclasses import dataclass
+
+
+class EchoServiceError(RuntimeError):
+    """Raised when the flaky echo service needs to signal a transient failure."""
+
+
+@dataclass
+class _FlakyState:
+    """Internal data structure to keep track of how many failures each client saw."""
+
+    attempts: int = 0
+
+
+# Module-level dictionary storing retry counts keyed by client identifier.
+_FLAKY_ATTEMPTS: dict[str, _FlakyState] = {}
+
+
+def get_echo_payload(message: str) -> dict[str, str]:
+    """Return the provided message wrapped in a JSON-friendly structure."""
+
+    return {"msg": message}
+
+
+def get_flaky_echo_payload(message: str, client_host: str, failures: int) -> dict[str, int | str]:
+    """Return the echoed message, simulating transient errors on earlier attempts.
+
+    Args:
+        message: The string submitted from the frontend form.
+        client_host: A stable identifier for the caller so each student sees their
+            own retry counter.
+        failures: The number of sequential failures to simulate before success.
+
+    Raises:
+        EchoServiceError: If the simulated service is still within the failure
+            window and needs the client to retry.
+    """
+
+    key = f"{client_host}:{failures}"
+    state = _FLAKY_ATTEMPTS.setdefault(key, _FlakyState())
+
+    if state.attempts < failures:
+        state.attempts += 1
+        raise EchoServiceError("Simulated transient failure")
+
+    attempts = state.attempts + 1  # Count the successful request as an attempt.
+    _FLAKY_ATTEMPTS[key] = _FlakyState()  # Reset tracking for the next exercise run.
+
+    return {"msg": message, "attempts": attempts}

--- a/ai-web/frontend/package-lock.json
+++ b/ai-web/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1385,6 +1386,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1421,6 +1431,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1445,6 +1466,12 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/ai-web/frontend/package.json
+++ b/ai-web/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",

--- a/ai-web/frontend/src/App.jsx
+++ b/ai-web/frontend/src/App.jsx
@@ -1,54 +1,20 @@
-import { useState } from 'react'; // Pull in React's state hook to manage component data.
-import { post } from './lib/api'; // Import the API helper that wraps fetch for POST requests.
-import { withRetry } from './lib/retry'; // Bring in the retry utility you created in Step 1.
+// Application shell responsible for wiring the echo feature into the page.
+//
+// Lab 02 promotes a feature-focused folder structure. This file stays intentionally
+// small so it is easy for students to see how the shared layout composes feature
+// modules exported from `src/features`.
+import { EchoForm } from './features/echo/components/EchoForm';
+import { useEchoForm } from './features/echo/hooks/useEchoForm';
 
-function App() { // Declare the main application component rendered by Vite.
-  const [msg, setMsg] = useState('hello'); // Track the message that the user wants to send to the backend.
-  const [response, setResponse] = useState(''); // Store the echoed response returned by the API.
-  const [loading, setLoading] = useState(false); // Represent whether a request is in progress so the UI can disable controls.
-  const [error, setError] = useState(''); // Hold a user-facing error message if all retries fail.
-
-  async function handleSend(event) { // Handle the form submission so we can prevent the default browser behavior.
-    event.preventDefault(); // Stop the browser from refreshing the page when the form is submitted.
-    setLoading(true); // Show the loading state while the request is running.
-    setError(''); // Clear any previous error message before retrying.
-    setResponse(''); // Reset the prior response so stale data is not displayed.
-    try {
-      const json = await withRetry(() => post('/echo', { msg }), 2, 500); // Attempt the POST request with up to two retries and a 500 ms delay.
-      setResponse(json.msg); // Store the echoed message if the request eventually succeeds.
-    } catch (err) {
-      setError('A temporary issue was encountered. Please try again.'); // Present a friendly message if every retry fails.
-    } finally {
-      setLoading(false); // Stop the loading indicator regardless of success or failure.
-    }
-  }
+function App() {
+  const echoForm = useEchoForm(); // Gather the state and handlers that power the echo feature.
 
   return (
-    <main style={{ padding: 24 }}> {/* Provide basic padding so the layout has breathing room. */}
-      <h1>Lab 2 — Echo with retries</h1> {/* Update the heading to reflect the new behavior in this lab. */}
-      <form onSubmit={handleSend} style={{ display: 'grid', gap: 12, maxWidth: 360 }}> {/* Use a simple grid layout for the form controls. */}
-        <label htmlFor="msg"> {/* Associate the label with the text input for accessibility. */}
-          Message to echo
-        </label>
-        <input
-          id="msg"
-          value={msg}
-          onChange={(event) => setMsg(event.target.value)}
-          disabled={loading}
-        /> {/* Bind the input to component state so the typed message is tracked. */}
-        <button type="submit" disabled={loading}> {/* Submit the form and disable the button when loading. */}
-          {loading ? 'Sending…' : 'Send'} {/* Swap button text based on the loading state. */}
-        </button>
-      </form>
-      {error && <p style={{ color: 'red' }}>{error}</p>} {/* Show a user-friendly error when retries fail. */}
-      {response && (
-        <section>
-          <h2>Server response</h2>
-          <pre>{response}</pre>
-        </section>
-      )} {/* Render the echoed message with a subheading when available. */}
+    <main style={{ padding: 24 }}>
+      {/* Spread the hook results onto the presentational component. */}
+      <EchoForm {...echoForm} />
     </main>
   );
 }
 
-export default App; // Export the component so main.jsx can render it.
+export default App;

--- a/ai-web/frontend/src/features/echo/components/EchoForm.jsx
+++ b/ai-web/frontend/src/features/echo/components/EchoForm.jsx
@@ -1,0 +1,54 @@
+// Presentational component responsible for rendering the echo form and results.
+//
+// The component receives all state and handlers from the `useEchoForm` hook so it
+// can focus on markup and teaching-friendly comments.
+import PropTypes from 'prop-types';
+
+export function EchoForm({
+  msg,
+  setMsg,
+  handleSubmit,
+  loading,
+  error,
+  response,
+}) {
+  return (
+    <section style={{ display: 'grid', gap: 16, maxWidth: 420 }}>
+      <header>
+        <h1>Lab 2 — Echo with retries</h1>
+        <p>
+          This form mirrors the curriculum&apos;s feature-folder layout. Submit a message to see
+          how the frontend retries the flaky endpoint before succeeding.
+        </p>
+      </header>
+      <form onSubmit={handleSubmit} style={{ display: 'grid', gap: 12 }}>
+        <label htmlFor="msg">Message to echo</label>
+        <input
+          id="msg"
+          value={msg}
+          onChange={(event) => setMsg(event.target.value)}
+          disabled={loading}
+        />
+        <button type="submit" disabled={loading}>
+          {loading ? 'Sending…' : 'Send'}
+        </button>
+      </form>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {response && (
+        <article>
+          <h2>Server response</h2>
+          <pre>{response}</pre>
+        </article>
+      )}
+    </section>
+  );
+}
+
+EchoForm.propTypes = {
+  msg: PropTypes.string.isRequired,
+  setMsg: PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+  loading: PropTypes.bool.isRequired,
+  error: PropTypes.string.isRequired,
+  response: PropTypes.string.isRequired,
+};

--- a/ai-web/frontend/src/features/echo/hooks/useEchoForm.js
+++ b/ai-web/frontend/src/features/echo/hooks/useEchoForm.js
@@ -1,0 +1,54 @@
+// Custom React hook that encapsulates the state and network calls for the echo form.
+//
+// Lab 02 encourages students to colocate hooks with the feature they support. This
+// implementation demonstrates that pattern by keeping the request logic next to
+// the UI while exposing a tiny API that the component can consume.
+import { useCallback, useState } from 'react';
+
+import { post } from '../../../lib/api';
+import { withRetry } from '../../../lib/retry';
+
+const DEFAULT_FAILURES = 2; // Fail twice before succeeding so the retry flow is visible.
+
+export function useEchoForm({ failures = DEFAULT_FAILURES } = {}) {
+  const [msg, setMsg] = useState('hello'); // Track the text field value.
+  const [response, setResponse] = useState(''); // Hold the JSON payload returned from the backend.
+  const [loading, setLoading] = useState(false); // Indicate when the form is sending a request.
+  const [error, setError] = useState(''); // Store a friendly message if every retry attempt fails.
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event?.preventDefault(); // Stop the browser from navigating away when the form submits.
+      setLoading(true); // Trigger the loading state immediately so the UI can disable inputs.
+      setError(''); // Clear any stale error message from a previous attempt.
+      setResponse(''); // Reset the response so old data does not flash between retries.
+
+      try {
+        const query = new URLSearchParams({ failures: failures.toString() });
+        const json = await withRetry(
+          () => post(`/flaky-echo?${query.toString()}`, { msg }),
+          failures,
+          500,
+        );
+
+        // Present the structured JSON so students can see how many attempts were needed.
+        setResponse(JSON.stringify(json, null, 2));
+      } catch (err) {
+        console.error('Echo request failed after retries', err); // Surface useful debugging info for the instructor console.
+        setError('A temporary issue was encountered. Please try again.');
+      } finally {
+        setLoading(false); // Always clear the loading flag once the promise settles.
+      }
+    },
+    [failures, msg],
+  );
+
+  return {
+    msg,
+    setMsg,
+    handleSubmit,
+    loading,
+    error,
+    response,
+  };
+}


### PR DESCRIPTION
## Summary
- move the echo endpoints into a dedicated router and service layer so the FastAPI structure matches the course labs
- refactor the React app into feature-scoped hooks and components that call the flaky echo endpoint with retries
- add prop-types for the new presentational component and surface the retry attempts in the rendered JSON response

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e158f87d348326ad41a01d6fdf86d6