### PR TITLE
Add Gemini lesson outline feature and workflow guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,46 @@
 # AI in Web Programming Lab Notebooks
 
-A collection of weekly lab notebooks lives under `ai-web/labs`. Each notebook follows the same structure (objectives, learning outcomes, prerequisites, guided steps, validation checks with local curl commands, and homework extensions) while covering the specific topics from the course brief.
+A collection of weekly lab notebooks lives under `ai-web/labs`. Each notebook
+follows the same structure (objectives, learning outcomes, prerequisites, guided
+steps, validation checks with local curl commands, and homework extensions)
+while covering the specific topics from the course brief.
 
 ## Backend stack
 
-The backend located at `ai-web/backend` is a FastAPI application served by Uvicorn. A small `EchoIn` Pydantic model validates the JSON payload sent from the frontend, while the `/health` route powers automated curl checks inside each lab. During development the app loads environment variables via `python-dotenv` so keys like `GEMINI_API_KEY` can be provided without committing secrets, and `CORSMiddleware` whitelists the Vite dev server origin for local testing.
+The backend located at `ai-web/backend` is a FastAPI application served by
+Uvicorn. A small `EchoIn` Pydantic model validates the JSON payload sent from the
+frontend, while the `/health` route powers automated curl checks inside each
+lab. During development the app loads environment variables via `python-dotenv`
+so keys like `GEMINI_API_KEY` can be provided without committing secrets, and
+`CORSMiddleware` whitelists the Vite dev server origin for local testing.
 
 ## Frontend stack
 
-The React frontend in `ai-web/frontend` is scaffolded with Vite. Components such as `App.jsx` demonstrate hook-based state management, and a reusable helper in `src/lib/api.js` wraps `fetch` calls to the backend. Vite injects `VITE_API_BASE` so the client knows where to send requests when running in Docker or against a deployed API.
+The React frontend in `ai-web/frontend` is scaffolded with Vite. Components such
+as `App.jsx` demonstrate hook-based state management, and a reusable helper in
+`src/lib/api.js` wraps `fetch` calls to the backend. Vite injects `VITE_API_BASE`
+so the client knows where to send requests when running in Docker or against a
+deployed API.
 
 ## Container orchestration
 
-`docker-compose.yml` builds and runs the frontend and backend containers side by side, publishing ports `5173` and `8000` to the host. The compose file mounts source code for hot reload, forwards `VITE_API_BASE` to the frontend, and points the backend at the `.env` file so secrets like `GEMINI_API_KEY` are loaded consistently.
+`docker-compose.yml` builds and runs the frontend and backend containers side by
+side, publishing ports `5173` and `8000` to the host. The compose file mounts
+source code for hot reload, forwards `VITE_API_BASE` to the frontend, and points
+the backend at the `.env` file so secrets like `GEMINI_API_KEY` are loaded
+consistently.
+
+## Instructor workflow
+
+See [`ai-web/docs/feature-workflow.md`](ai-web/docs/feature-workflow.md) for a
+step-by-step walkthrough that shows how to add new routers/services on the
+backend and matching hooks/components on the frontend. The document mirrors the
+lab exercises and serves as a ready-to-teach script when extending the project
+with AI-driven demos.
 
 ## Notebook generator
 
-The script `generate_ai_web_lab_notebooks.py` programmatically scaffolds each lab notebook. It ensures sections such as objectives, prerequisites, validation steps, and homework prompts follow a consistent template across the course, making it easier to maintain and extend the curriculum.
+The script `generate_ai_web_lab_notebooks.py` programmatically scaffolds each
+lab notebook. It ensures sections such as objectives, prerequisites, validation
+steps, and homework prompts follow a consistent template across the course,
+making it easier to maintain and extend the curriculum.

--- a/ai-web/backend/.env.example
+++ b/ai-web/backend/.env.example
@@ -1,2 +1,4 @@
 # Environment variables (never commit real keys)
 GEMINI_API_KEY=
+# Override the default Gemini model if you need a specific capability.
+GEMINI_MODEL=

--- a/ai-web/backend/app/main.py
+++ b/ai-web/backend/app/main.py
@@ -1,61 +1,30 @@
-"""FastAPI backend powering the lab exercises.
-
-This lightweight service exposes a health check and an echo endpoint that the
-frontend labs call during development. CORS middleware is configured so the
-Vite dev server can reach the API from a different origin while students test
-their work locally.
-"""
+"""FastAPI application entry point used by the lab backend container."""
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+
+from app.routers.echo import router as echo_router
+from app.routers.gemini import router as gemini_router
 
 # Load environment variables from a local .env file when present so the
 # application picks up credentials configured for the labs.
 load_dotenv()
 
-app = FastAPI()  # Entry point creation
+app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],  # Permit the local Vite dev server.
+    allow_origins=["http://localhost:5173"],
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
-
-# Track transient failure counts per client to simulate flaky behavior.
-_flaky_attempts: dict[str, int] = {}
-
-
-class EchoIn(BaseModel):
-    """Payload schema for `/echo`, carrying the text entered in the labs."""
-    msg: str
+app.include_router(echo_router)
+app.include_router(gemini_router)
 
 
 @app.get("/health")
-def health():
+def health() -> dict[str, str]:
     """Report service status for lab curl checks and container health probes."""
+
     return {"status": "ok"}
-
-
-@app.post("/echo")
-def echo(payload: EchoIn):
-    """Echo the provided message so students can verify request/response flows."""
-    return {"msg": payload.msg}
-
-
-@app.post("/flaky-echo")
-def flaky_echo(payload: EchoIn, request: Request, failures: int = 1):
-    """Simulate transient failures before eventually echoing the payload."""
-
-    client_host = request.client.host if request.client else "unknown"
-    key = f"{client_host}:{failures}"
-    seen = _flaky_attempts.get(key, 0)
-
-    if seen < failures:
-        _flaky_attempts[key] = seen + 1
-        raise HTTPException(status_code=503, detail="Simulated transient failure")
-
-    _flaky_attempts[key] = 0
-    return {"msg": payload.msg, "attempts": seen + 1}

--- a/ai-web/backend/app/routers/__init__.py
+++ b/ai-web/backend/app/routers/__init__.py
@@ -1,0 +1,6 @@
+"""Router modules for the lab backend.
+
+Routers group related endpoints together so the FastAPI entry point in
+``app/main.py`` can stay focused on application setup. See ``echo`` and
+``gemini`` for concrete examples used throughout the AI in Web curriculum.
+"""

--- a/ai-web/backend/app/routers/echo.py
+++ b/ai-web/backend/app/routers/echo.py
@@ -1,0 +1,43 @@
+"""Echo-related API routes used throughout the web programming labs.
+
+The router exposes the lab's simple `/echo` endpoint alongside a `/flaky-echo`
+variant that intentionally fails a configurable number of times.  Keeping these
+routes in a dedicated module mirrors the folder structure that students build in
+Lab 01, where routers, services, and schemas live in their own packages.
+"""
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from app.services.echo import EchoServiceError, get_echo_payload, get_flaky_echo_payload
+
+router = APIRouter(tags=["echo"])
+
+
+class EchoIn(BaseModel):
+    """Pydantic model describing the request body submitted from the frontend."""
+
+    msg: str
+
+
+@router.post("/echo")
+def echo(payload: EchoIn) -> dict[str, str]:
+    """Return the payload unchanged so students can verify request plumbing."""
+
+    return get_echo_payload(payload.msg)
+
+
+@router.post("/flaky-echo")
+def flaky_echo(payload: EchoIn, request: Request, failures: int = 1) -> dict[str, int | str]:
+    """Simulate transient failures before eventually returning the echoed message.
+
+    The router delegates the retry tracking to the service layer so the example
+    mirrors the lab notes that encourage thin route handlers.
+    """
+
+    client_host = request.client.host if request.client else "unknown"
+
+    try:
+        return get_flaky_echo_payload(payload.msg, client_host, failures)
+    except EchoServiceError as exc:  # Translate the domain error into an HTTP error.
+        raise HTTPException(status_code=503, detail=str(exc)) from exc

--- a/ai-web/backend/app/routers/gemini.py
+++ b/ai-web/backend/app/routers/gemini.py
@@ -1,0 +1,33 @@
+"""API routes that expose Gemini-backed helpers to the frontend."""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.services.gemini import GeminiServiceError, generate_lesson_outline
+
+router = APIRouter(prefix="/ai", tags=["ai"])
+
+
+class LessonOutlineIn(BaseModel):
+    """Request schema describing the lesson topic submitted by the frontend."""
+
+    topic: str
+
+
+class LessonOutlineOut(BaseModel):
+    """Response schema returned to the frontend."""
+
+    topic: str
+    outline: list[str]
+
+
+@router.post("/lesson-outline", response_model=LessonOutlineOut)
+def lesson_outline(payload: LessonOutlineIn) -> LessonOutlineOut:
+    """Delegate the heavy lifting to the Gemini service layer."""
+
+    try:
+        result = generate_lesson_outline(payload.topic)
+    except GeminiServiceError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    return LessonOutlineOut(**result)

--- a/ai-web/backend/app/services/__init__.py
+++ b/ai-web/backend/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service-layer helpers for FastAPI routers used in the labs."""

--- a/ai-web/backend/app/services/echo.py
+++ b/ai-web/backend/app/services/echo.py
@@ -1,0 +1,57 @@
+"""Service helpers containing the business logic for the echo endpoints.
+
+The routers import these helpers so that the FastAPI layer remains focused on
+HTTP details while the service layer owns the stateful retry simulation.  This
+matches the separation of concerns demonstrated in the accompanying lab
+notebooks and gives instructors a concrete example to reference in class.
+"""
+
+from dataclasses import dataclass
+
+
+class EchoServiceError(RuntimeError):
+    """Raised when the flaky echo service needs to signal a transient failure."""
+
+
+@dataclass
+class _FlakyState:
+    """Internal data structure to keep track of how many failures each client saw."""
+
+    attempts: int = 0
+
+
+# Module-level dictionary storing retry counts keyed by client identifier.
+_FLAKY_ATTEMPTS: dict[str, _FlakyState] = {}
+
+
+def get_echo_payload(message: str) -> dict[str, str]:
+    """Return the provided message wrapped in a JSON-friendly structure."""
+
+    return {"msg": message}
+
+
+def get_flaky_echo_payload(message: str, client_host: str, failures: int) -> dict[str, int | str]:
+    """Return the echoed message, simulating transient errors on earlier attempts.
+
+    Args:
+        message: The string submitted from the frontend form.
+        client_host: A stable identifier for the caller so each student sees their
+            own retry counter.
+        failures: The number of sequential failures to simulate before success.
+
+    Raises:
+        EchoServiceError: If the simulated service is still within the failure
+            window and needs the client to retry.
+    """
+
+    key = f"{client_host}:{failures}"
+    state = _FLAKY_ATTEMPTS.setdefault(key, _FlakyState())
+
+    if state.attempts < failures:
+        state.attempts += 1
+        raise EchoServiceError("Simulated transient failure")
+
+    attempts = state.attempts + 1  # Count the successful request as an attempt.
+    _FLAKY_ATTEMPTS[key] = _FlakyState()  # Reset tracking for the next exercise run.
+
+    return {"msg": message, "attempts": attempts}

--- a/ai-web/backend/app/services/gemini.py
+++ b/ai-web/backend/app/services/gemini.py
@@ -1,0 +1,91 @@
+"""Service helpers for Gemini-powered features exposed by the FastAPI app.
+
+The teaching labs encourage a service layer that contains the business logic
+for each feature. Routers stay thin while services interact with third-party
+SDKs or databases. This module demonstrates that pattern for Gemini requests.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import List
+
+try:  # Import the Gemini SDK lazily so unit tests can run without the package.
+    import google.generativeai as genai
+except ImportError as exc:  # pragma: no cover - handled during runtime usage.
+    genai = None  # type: ignore[assignment]
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+
+class GeminiServiceError(RuntimeError):
+    """Raised when the Gemini helper cannot fulfill a request."""
+
+
+def _require_api_key() -> str:
+    """Read the API key from the environment and raise a descriptive error."""
+
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        raise GeminiServiceError(
+            "GEMINI_API_KEY is not configured. Add it to backend/.env before calling the service."
+        )
+    return api_key
+
+
+@lru_cache(maxsize=1)
+def _configure_client(api_key: str) -> bool:
+    """Configure the global Gemini client once per process."""
+
+    if genai is None:  # pragma: no cover - depends on optional dependency.
+        raise GeminiServiceError(
+            "google-generativeai is not installed. Run `pip install google-genai` to enable the feature."
+        ) from _IMPORT_ERROR
+
+    genai.configure(api_key=api_key)
+    return True
+
+
+def _parse_outline_lines(raw_outline: str) -> List[str]:
+    """Convert the model response into a clean list of outline bullet points."""
+
+    lines: List[str] = []
+    for line in raw_outline.splitlines():
+        cleaned = line.strip()
+        if not cleaned:
+            continue
+        # Remove leading numbering/bullet characters that models often return.
+        cleaned = cleaned.lstrip("-*•0123456789. \t")
+        if cleaned:
+            lines.append(cleaned)
+    return lines
+
+
+def generate_lesson_outline(topic: str, model: str | None = None) -> dict[str, str | list[str]]:
+    """Generate a course outline for the requested topic using Gemini."""
+
+    normalized_topic = topic.strip()
+    if not normalized_topic:
+        raise GeminiServiceError("Topic must not be empty.")
+
+    api_key = _require_api_key()
+    _configure_client(api_key)
+
+    selected_model = model or os.getenv("GEMINI_MODEL", "gemini-1.5-flash")
+    try:
+        generative_model = genai.GenerativeModel(selected_model)
+        prompt = (
+            "You are helping an instructor design a web programming lesson. "
+            "Return a concise outline with 3-5 bullet points that cover the key "
+            "concepts for the topic: "
+            f"{normalized_topic}."
+        )
+        response = generative_model.generate_content(prompt)
+        outline_text = getattr(response, "text", "").strip()
+    except Exception as exc:  # pragma: no cover - depends on remote API.
+        raise GeminiServiceError("Failed to generate lesson outline.") from exc
+
+    outline = _parse_outline_lines(outline_text) if outline_text else []
+    return {"topic": normalized_topic, "outline": outline}

--- a/ai-web/docs/feature-workflow.md
+++ b/ai-web/docs/feature-workflow.md
@@ -1,0 +1,70 @@
+# Full-stack feature workflow
+
+This guide documents the classroom-friendly workflow for adding a new feature to
+the AI in Web Programming labs. Follow the steps sequentially so the backend and
+frontend stay in sync and mirror the structure students build in Lab 01–03.
+
+## 1. Design the service layer
+
+1. Create a module under [`app/services`](../backend/app/services) that contains
+   the core business logic. Use [`services/echo.py`](../backend/app/services/echo.py)
+   and [`services/gemini.py`](../backend/app/services/gemini.py) as references for
+   docstring-heavy helpers and error handling.
+2. Load secrets through environment variables (`python-dotenv` is wired up in
+   [`app/main.py`](../backend/app/main.py)). Provide clear error messages so
+   instructors can demo misconfiguration scenarios.
+
+## 2. Expose the functionality via a router
+
+1. Add a new router module to [`app/routers`](../backend/app/routers). Keep the
+   handlers thin by importing the service function you created in the previous
+   step. See [`routers/echo.py`](../backend/app/routers/echo.py) and
+   [`routers/gemini.py`](../backend/app/routers/gemini.py) for examples of
+   defining request/response models next to the route.
+2. Register the router inside [`app/main.py`](../backend/app/main.py) with
+   `app.include_router`. This keeps the application entry point as the single
+   place that assembles middleware and routes.
+
+## 3. Add a matching frontend feature
+
+1. Scaffold a new folder in [`frontend/src/features`](../frontend/src/features)
+   with `components/` and `hooks/` subdirectories. Each feature exposes a hook
+   that performs data fetching (e.g. [`useEchoForm`](../frontend/src/features/echo/hooks/useEchoForm.js)
+   and [`useLessonOutlineForm`](../frontend/src/features/gemini/hooks/useLessonOutlineForm.js)).
+2. Build a presentational component that receives the hook’s state/handlers via
+   props. [`EchoForm`](../frontend/src/features/echo/components/EchoForm.jsx) and
+   [`LessonOutlineForm`](../frontend/src/features/gemini/components/LessonOutlineForm.jsx)
+   showcase how to document props with `prop-types` and render helpful teaching
+   copy alongside the UI.
+3. Update [`src/App.jsx`](../frontend/src/App.jsx) to import the new feature and
+   render it in the layout. Keep the application shell focused on composition so
+   students can scan it quickly during lectures.
+
+## 4. Wire up environment variables
+
+1. Document new keys in [`backend/.env.example`](../backend/.env.example) and
+   [`frontend/.env.example`](../frontend/.env.example). The instructor can copy
+   these files to `.env` when preparing demos.
+2. When introducing AI-powered flows, store API keys on the backend and proxy
+   requests through FastAPI. The Gemini example keeps secrets server-side while
+   the frontend calls `/ai/lesson-outline` via [`lib/api.js`](../frontend/src/lib/api.js).
+
+## 5. Validate the end-to-end flow
+
+1. Start the backend with `uvicorn app.main:app --reload` and the frontend with
+   `npm run dev` from `ai-web/frontend`. Confirm both sections of the UI load in
+   the browser.
+2. Use `curl` to test new endpoints directly. For example:
+
+   ```bash
+   curl -X POST http://localhost:8000/ai/lesson-outline \
+     -H 'Content-Type: application/json' \
+     -d '{"topic": "State management in React"}'
+   ```
+
+3. Demonstrate error handling by temporarily removing environment variables or
+   by adjusting query parameters (e.g. hitting `/flaky-echo?failures=3`). Discuss
+   how the frontend surfaces these failures to students.
+
+Following this workflow keeps the curriculum consistent and gives learners a
+repeatable process for building their own features.

--- a/ai-web/frontend/.env.example
+++ b/ai-web/frontend/.env.example
@@ -1,0 +1,10 @@
+# Frontend environment variables consumed by Vite during local development.
+#
+# Point the React app at a different backend host/port when running outside of
+# docker-compose.
+VITE_API_BASE=http://localhost:8000
+
+# Surface the Gemini key to the frontend only when the teaching material needs
+# to call AI services directly from the browser (default flow keeps calls on the
+# backend). Keep this empty unless absolutely required.
+VITE_GEMINI_API_KEY=

--- a/ai-web/frontend/README.md
+++ b/ai-web/frontend/README.md
@@ -1,0 +1,32 @@
+# Frontend
+
+This Vite-powered React app mirrors the feature-oriented structure taught in the
+AI in Web Programming labs. Each feature owns a `hooks/` folder for data-fetching
+logic and a `components/` folder for presentational UI.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+The app expects `VITE_API_BASE` to point at the FastAPI backend. When using the
+provided `docker-compose.yml`, the variable is forwarded automatically. For a
+standalone dev server, copy `.env.example` to `.env` and update the host/port as
+needed.
+
+## Adding a new feature
+
+1. Follow the backend workflow in [`../docs/feature-workflow.md`](../docs/feature-workflow.md)
+   to create a service and router.
+2. Create a new folder under [`src/features`](src/features) with `hooks/` and
+   `components/` subdirectories. Export a hook that wraps API calls via
+   [`src/lib/api.js`](src/lib/api.js) and a component that documents its props with
+   `prop-types`.
+3. Compose the new feature inside [`src/App.jsx`](src/App.jsx) so the UI surfaces
+   both the teaching copy and the interactive demo.
+
+For AI-powered flows, keep secrets on the backend by default. The optional
+`VITE_GEMINI_API_KEY` entry in `.env.example` is available only if a lesson
+requires direct browser access to Gemini.

--- a/ai-web/frontend/package-lock.json
+++ b/ai-web/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1385,6 +1386,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1421,6 +1431,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1445,6 +1466,12 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/ai-web/frontend/package.json
+++ b/ai-web/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",

--- a/ai-web/frontend/src/App.jsx
+++ b/ai-web/frontend/src/App.jsx
@@ -1,54 +1,40 @@
-import { useState } from 'react'; // Pull in React's state hook to manage component data.
-import { post } from './lib/api'; // Import the API helper that wraps fetch for POST requests.
-import { withRetry } from './lib/retry'; // Bring in the retry utility you created in Step 1.
+// Application shell responsible for wiring feature modules into the page.
+//
+// Each lab encourages keeping this component small so students can focus on the
+// feature folders under `src/features`. New demos should follow the same
+// pattern: create a hook for stateful logic and pass it into a presentational
+// component.
+import { EchoForm } from './features/echo/components/EchoForm';
+import { useEchoForm } from './features/echo/hooks/useEchoForm';
+import { LessonOutlineForm } from './features/gemini/components/LessonOutlineForm';
+import { useLessonOutlineForm } from './features/gemini/hooks/useLessonOutlineForm';
 
-function App() { // Declare the main application component rendered by Vite.
-  const [msg, setMsg] = useState('hello'); // Track the message that the user wants to send to the backend.
-  const [response, setResponse] = useState(''); // Store the echoed response returned by the API.
-  const [loading, setLoading] = useState(false); // Represent whether a request is in progress so the UI can disable controls.
-  const [error, setError] = useState(''); // Hold a user-facing error message if all retries fail.
-
-  async function handleSend(event) { // Handle the form submission so we can prevent the default browser behavior.
-    event.preventDefault(); // Stop the browser from refreshing the page when the form is submitted.
-    setLoading(true); // Show the loading state while the request is running.
-    setError(''); // Clear any previous error message before retrying.
-    setResponse(''); // Reset the prior response so stale data is not displayed.
-    try {
-      const json = await withRetry(() => post('/echo', { msg }), 2, 500); // Attempt the POST request with up to two retries and a 500 ms delay.
-      setResponse(json.msg); // Store the echoed message if the request eventually succeeds.
-    } catch (err) {
-      setError('A temporary issue was encountered. Please try again.'); // Present a friendly message if every retry fails.
-    } finally {
-      setLoading(false); // Stop the loading indicator regardless of success or failure.
-    }
-  }
+function App() {
+  const echoForm = useEchoForm();
+  const lessonOutlineForm = useLessonOutlineForm();
 
   return (
-    <main style={{ padding: 24 }}> {/* Provide basic padding so the layout has breathing room. */}
-      <h1>Lab 2 — Echo with retries</h1> {/* Update the heading to reflect the new behavior in this lab. */}
-      <form onSubmit={handleSend} style={{ display: 'grid', gap: 12, maxWidth: 360 }}> {/* Use a simple grid layout for the form controls. */}
-        <label htmlFor="msg"> {/* Associate the label with the text input for accessibility. */}
-          Message to echo
-        </label>
-        <input
-          id="msg"
-          value={msg}
-          onChange={(event) => setMsg(event.target.value)}
-          disabled={loading}
-        /> {/* Bind the input to component state so the typed message is tracked. */}
-        <button type="submit" disabled={loading}> {/* Submit the form and disable the button when loading. */}
-          {loading ? 'Sending…' : 'Send'} {/* Swap button text based on the loading state. */}
-        </button>
-      </form>
-      {error && <p style={{ color: 'red' }}>{error}</p>} {/* Show a user-friendly error when retries fail. */}
-      {response && (
-        <section>
-          <h2>Server response</h2>
-          <pre>{response}</pre>
-        </section>
-      )} {/* Render the echoed message with a subheading when available. */}
+    <main style={{ padding: 24, display: 'grid', gap: 32 }}>
+      <header style={{ display: 'grid', gap: 8 }}>
+        <h1>AI in Web Programming Demos</h1>
+        <p>
+          Use these examples to show students how the FastAPI and React layers
+          evolve together. Each section mirrors the workflow documented in the
+          instructor guide.
+        </p>
+      </header>
+
+      <section style={{ display: 'grid', gap: 16 }}>
+        <h2>Retrying echo service</h2>
+        <EchoForm {...echoForm} />
+      </section>
+
+      <section style={{ display: 'grid', gap: 16 }}>
+        <h2>Gemini lesson outline builder</h2>
+        <LessonOutlineForm {...lessonOutlineForm} />
+      </section>
     </main>
   );
 }
 
-export default App; // Export the component so main.jsx can render it.
+export default App;

--- a/ai-web/frontend/src/features/echo/components/EchoForm.jsx
+++ b/ai-web/frontend/src/features/echo/components/EchoForm.jsx
@@ -1,0 +1,54 @@
+// Presentational component responsible for rendering the echo form and results.
+//
+// The component receives all state and handlers from the `useEchoForm` hook so it
+// can focus on markup and teaching-friendly comments.
+import PropTypes from 'prop-types';
+
+export function EchoForm({
+  msg,
+  setMsg,
+  handleSubmit,
+  loading,
+  error,
+  response,
+}) {
+  return (
+    <section style={{ display: 'grid', gap: 16, maxWidth: 420 }}>
+      <header>
+        <h1>Lab 2 — Echo with retries</h1>
+        <p>
+          This form mirrors the curriculum&apos;s feature-folder layout. Submit a message to see
+          how the frontend retries the flaky endpoint before succeeding.
+        </p>
+      </header>
+      <form onSubmit={handleSubmit} style={{ display: 'grid', gap: 12 }}>
+        <label htmlFor="msg">Message to echo</label>
+        <input
+          id="msg"
+          value={msg}
+          onChange={(event) => setMsg(event.target.value)}
+          disabled={loading}
+        />
+        <button type="submit" disabled={loading}>
+          {loading ? 'Sending…' : 'Send'}
+        </button>
+      </form>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {response && (
+        <article>
+          <h2>Server response</h2>
+          <pre>{response}</pre>
+        </article>
+      )}
+    </section>
+  );
+}
+
+EchoForm.propTypes = {
+  msg: PropTypes.string.isRequired,
+  setMsg: PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+  loading: PropTypes.bool.isRequired,
+  error: PropTypes.string.isRequired,
+  response: PropTypes.string.isRequired,
+};

--- a/ai-web/frontend/src/features/echo/hooks/useEchoForm.js
+++ b/ai-web/frontend/src/features/echo/hooks/useEchoForm.js
@@ -1,0 +1,54 @@
+// Custom React hook that encapsulates the state and network calls for the echo form.
+//
+// Lab 02 encourages students to colocate hooks with the feature they support. This
+// implementation demonstrates that pattern by keeping the request logic next to
+// the UI while exposing a tiny API that the component can consume.
+import { useCallback, useState } from 'react';
+
+import { post } from '../../../lib/api';
+import { withRetry } from '../../../lib/retry';
+
+const DEFAULT_FAILURES = 2; // Fail twice before succeeding so the retry flow is visible.
+
+export function useEchoForm({ failures = DEFAULT_FAILURES } = {}) {
+  const [msg, setMsg] = useState('hello'); // Track the text field value.
+  const [response, setResponse] = useState(''); // Hold the JSON payload returned from the backend.
+  const [loading, setLoading] = useState(false); // Indicate when the form is sending a request.
+  const [error, setError] = useState(''); // Store a friendly message if every retry attempt fails.
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event?.preventDefault(); // Stop the browser from navigating away when the form submits.
+      setLoading(true); // Trigger the loading state immediately so the UI can disable inputs.
+      setError(''); // Clear any stale error message from a previous attempt.
+      setResponse(''); // Reset the response so old data does not flash between retries.
+
+      try {
+        const query = new URLSearchParams({ failures: failures.toString() });
+        const json = await withRetry(
+          () => post(`/flaky-echo?${query.toString()}`, { msg }),
+          failures,
+          500,
+        );
+
+        // Present the structured JSON so students can see how many attempts were needed.
+        setResponse(JSON.stringify(json, null, 2));
+      } catch (err) {
+        console.error('Echo request failed after retries', err); // Surface useful debugging info for the instructor console.
+        setError('A temporary issue was encountered. Please try again.');
+      } finally {
+        setLoading(false); // Always clear the loading flag once the promise settles.
+      }
+    },
+    [failures, msg],
+  );
+
+  return {
+    msg,
+    setMsg,
+    handleSubmit,
+    loading,
+    error,
+    response,
+  };
+}

--- a/ai-web/frontend/src/features/gemini/components/LessonOutlineForm.jsx
+++ b/ai-web/frontend/src/features/gemini/components/LessonOutlineForm.jsx
@@ -1,0 +1,56 @@
+// Presentational component that renders the Gemini lesson outline form.
+import PropTypes from 'prop-types';
+
+export function LessonOutlineForm({ topic, setTopic, outline, loading, error, handleSubmit }) {
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'grid', gap: 12 }}>
+      <p>
+        Generate a quick lesson outline powered by Gemini. Provide a topic, submit
+        the form, and discuss the generated talking points with your class.
+      </p>
+
+      <label style={{ display: 'grid', gap: 4 }}>
+        <span>Lesson topic</span>
+        <input
+          type="text"
+          value={topic}
+          onChange={(event) => setTopic(event.target.value)}
+          placeholder="e.g. Building resilient web APIs"
+          disabled={loading}
+          required
+        />
+      </label>
+
+      <button type="submit" disabled={loading || !topic.trim()}>
+        {loading ? 'Generating outline…' : 'Generate outline'}
+      </button>
+
+      {error && (
+        <p style={{ color: 'crimson' }}>
+          {error}. Confirm the backend has access to <code>GEMINI_API_KEY</code>.
+        </p>
+      )}
+
+      {outline.length > 0 && (
+        <ol>
+          {outline.map((item, index) => (
+            <li key={`${item}-${index}`}>{item}</li>
+          ))}
+        </ol>
+      )}
+    </form>
+  );
+}
+
+LessonOutlineForm.propTypes = {
+  topic: PropTypes.string.isRequired,
+  setTopic: PropTypes.func.isRequired,
+  outline: PropTypes.arrayOf(PropTypes.string).isRequired,
+  loading: PropTypes.bool.isRequired,
+  error: PropTypes.string,
+  handleSubmit: PropTypes.func.isRequired
+};
+
+LessonOutlineForm.defaultProps = {
+  error: null
+};

--- a/ai-web/frontend/src/features/gemini/hooks/useLessonOutlineForm.js
+++ b/ai-web/frontend/src/features/gemini/hooks/useLessonOutlineForm.js
@@ -1,0 +1,55 @@
+// Hook encapsulating the state management for the Gemini lesson outline form.
+// The labs emphasise isolating fetch logic inside hooks so components stay
+// presentational and easy to reuse in lectures.
+import { useCallback, useState } from 'react';
+
+import { post } from '../../../lib/api';
+
+const ENDPOINT = '/ai/lesson-outline';
+
+/**
+ * Manage the lesson outline form lifecycle.
+ *
+ * @returns {object} Handlers and state consumed by the presentational component.
+ */
+export function useLessonOutlineForm() {
+  const [topic, setTopic] = useState('');
+  const [outline, setOutline] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event.preventDefault();
+      const trimmedTopic = topic.trim();
+      if (!trimmedTopic) {
+        setError('Please enter a topic.');
+        setOutline([]);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await post(ENDPOINT, { topic: trimmedTopic });
+        setOutline(Array.isArray(response.outline) ? response.outline : []);
+      } catch (err) {
+        setOutline([]);
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [topic]
+  );
+
+  return {
+    topic,
+    setTopic,
+    outline,
+    loading,
+    error,
+    handleSubmit
+  };
+}


### PR DESCRIPTION
## Summary
- add a Gemini-backed service and router so the FastAPI app can generate lesson outlines alongside the echo demo
- build a matching React feature with hooks/components plus env examples to surface the AI workflow to students
- document the instructor workflow for adding full-stack features and link the new guide from the root and frontend READMEs

## Testing
- npm run build
- python -m compileall ai-web/backend/app

------
https://chatgpt.com/codex/tasks/task_e_68e158f87d348326ad41a01d6fdf86d6